### PR TITLE
Use collective.deletepermission

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -361,6 +361,22 @@ What is tested?
     </configure>
 
 
+Specialities
+------------
+
+Deleting content
+~~~~~~~~~~~~~~~~
+
+The ftw.lawgiver uses `collective.deletepermission`_.
+If you generate a workflow using lawgiver and install it in production without lawgiver, be sure
+to install `collective.deletepermission`_!
+
+`collective.deletepermission`_ solves a delete problem which occurs in certain situations by
+adding a new delete permission. See its readme for further details.
+
+For beeing able to delete a content, the user should have the "delete" action
+group (`Delete portal content`) on the content but also "add" (`Delete objects`) on the parent content
+
 
 Example
 -------
@@ -369,6 +385,7 @@ In our tests we have an up to date
 `example specification.txt <https://github.com/4teamwork/ftw.lawgiver/blob/master/ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt>`_, from which the
 `definition.xml <https://github.com/4teamwork/ftw.lawgiver/blob/master/ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/definition.xml>`_
 is generated.
+
 
 
 Links
@@ -386,3 +403,5 @@ Copyright
 This package is copyright by `4teamwork <http://www.4teamwork.ch/>`_.
 
 ``ftw.lawgiver`` is licensed under GNU General Public License, version 2.
+
+.. _collective.deletepermission: https://github.com/4teamwork/collective.deletepermission

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -74,6 +74,7 @@
                      Add portal events,
                      Add portal folders,
                      Add portal topics,
+                     Delete objects,
                      PloneFormGen: Add Content,
                      plone.app.collection: Add Collection,
 
@@ -83,9 +84,7 @@
 
     <lawgiver:map_permissions
         action_group="delete"
-        permissions="
-                     Delete objects,
-                     "
+        permissions="Delete portal content"
         />
 
 

--- a/ftw/lawgiver/profiles/default/metadata.xml
+++ b/ftw/lawgiver/profiles/default/metadata.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
 <metadata>
     <version>1000</version>
+    <dependencies>
+        <dependency>profile-collective.deletepermission:default</dependency>
+    </dependencies>
 </metadata>

--- a/ftw/lawgiver/tests/assets/example/definition.xml
+++ b/ftw/lawgiver/tests/assets/example/definition.xml
@@ -39,6 +39,7 @@
   <permission>Content rules: Manage rules</permission>
   <permission>Copy or Move</permission>
   <permission>Delete objects</permission>
+  <permission>Delete portal content</permission>
   <permission>List folder contents</permission>
   <permission>List undoable changes</permission>
   <permission>Manage properties</permission>
@@ -159,6 +160,10 @@
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Reviewer</permission-role>
+    </permission-map>
+    <permission-map name="Delete portal content" acquired="False">
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
@@ -307,6 +312,10 @@
     <permission-map name="Delete objects" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
+    </permission-map>
+    <permission-map name="Delete portal content" acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="List folder contents" acquired="False">
@@ -442,6 +451,10 @@
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Reviewer</permission-role>
+    </permission-map>
+    <permission-map name="Delete portal content" acquired="False">
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="List folder contents" acquired="False">

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(name='ftw.lawgiver',
         'zope.interface',
         'zope.publisher',
         'zope.schema',
+        'collective.deletepermission',
 
         ],
 


### PR DESCRIPTION
This pull-request integrates collective.deletepermission.
The `Delete objects` is mapped to "view" and `Delete portal content` to "delete".

@maethu I'm not quite sure if that is a good idea.
Mapping `Delete objects` to "View" will cause Anonymous to have this permission.
Although collective.deletepermission _should_ take care that this permission alone is not enough
it is still a security risk (e.g. when collective.deletepermission doesnt't do the job after a plone update).
But I'm not sure how to map it differently so that it works.

Should we maybe not manage `Delete objects` in the workflow at all?

/cc @phabegger
