### PR TITLE
Add a "ignore" directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -421,9 +421,8 @@ What is tested?
         <include package="ftw.lawgiver" file="meta.zcml" />
 
 
-        <lawgiver:map_permissions
-            action_group="__unmanaged__"
-            workflow="__unmanaged__"
+        <lawgiver:ignore
+            workflow="my_workflow"
             permissions="ATContentTypes: Upload via url,
                          ATContentTypes: View history"
             />

--- a/ftw/lawgiver/interfaces.py
+++ b/ftw/lawgiver/interfaces.py
@@ -21,6 +21,12 @@ class IActionGroupRegistry(Interface):
         optional only for a specific `workflow`.
         """
 
+    def ignore(permissions, workflow=None):
+        """Ignore permissions for all workflows or for a single workflow.
+        This will cause that these permissions are not managed by the
+        workflow at all.
+        """
+
     def get_action_groups_for_workflow(workflow_name):
         """Returns a action groups to permissions mapping for a specific
         workflow (by `workflow_name`).
@@ -34,6 +40,11 @@ class IActionGroupRegistry(Interface):
         Optional the `workflow_name` can be passed to make the query workflow
         specific.
         If the permission is not mapped, None is returned.
+        """
+
+    def get_ignored_permissions(workflow_name=None):
+        """Returns all ignored permissions in general or for a specific
+        workflow.
         """
 
 

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -134,9 +134,7 @@
         />
 
 
-    <lawgiver:map_permissions
-        action_group="__unmanaged__"
-        workflow="__unmanaged__"
+    <lawgiver:ignore
         permissions="
 
                      ATContentTypes: Upload via url,
@@ -287,9 +285,7 @@
     <!-- we do not use "Request review" / "Review portal content" by
          default, since we use role-based transition guards. -->
 
-    <lawgiver:map_permissions
-        action_group="__unmanaged__"
-        workflow="__unmanaged__"
+    <lawgiver:ignore
         permissions="
                      Review portal content,
                      Request review,
@@ -301,9 +297,7 @@
          manage_access with the message id rather the translation default, which we
          do not want to add to the workflow. Therefore we mark them as unmanaged -->
 
-    <lawgiver:map_permissions
-        action_group="__unmanaged__"
-        workflow="__unmanaged__"
+    <lawgiver:ignore
         permissions="
                      change-security-settings-permission,
                      manage-content-permission,

--- a/ftw/lawgiver/meta.py
+++ b/ftw/lawgiver/meta.py
@@ -29,6 +29,22 @@ class IMapPermissionsDirective(Interface):
         required=False)
 
 
+class IIgnorePermissionsDirective(Interface):
+
+    permissions = CommaSeparatedText(
+        title=u'Permissions',
+        description=u'A list of permissions',
+        required=True)
+
+    workflow = TextLine(
+        title=u'The name of the workflow',
+        description=u'By default the directive contents'
+        u' apply to all workflows. Set the name of the'
+        u' workflow here for making it workflow specific.',
+        default=None,
+        required=False)
+
+
 def mapPermissions(_context, **kwargs):
     """Map permissions to an action group.
     """
@@ -49,3 +65,25 @@ def mapPermissions(_context, **kwargs):
         provideUtility(component)
 
     component.update(**kwargs)
+
+
+def ignorePermissions(_context, **kwargs):
+    """Ignore permissions for a workflow.
+    """
+
+    permissions = kwargs['permissions']
+    for permission in permissions:
+        if '   ' in permission:
+            raise ConfigurationError(
+                'Seems that a comma is missing in the "permissions"'
+                ' attribute of the lawgiver:map_permissions tag.')
+
+    if permissions[-1] == '':
+        permissions.pop()
+
+    component = queryUtility(IActionGroupRegistry)
+    if component is None:
+        component = ActionGroupRegistry()
+        provideUtility(component)
+
+    component.ignore(**kwargs)

--- a/ftw/lawgiver/meta.zcml
+++ b/ftw/lawgiver/meta.zcml
@@ -9,4 +9,11 @@
         handler=".meta.mapPermissions"
         />
 
+    <meta:directive
+        namespace="http://namespaces.zope.org/lawgiver"
+        name="ignore"
+        schema=".meta.IIgnorePermissionsDirective"
+        handler=".meta.ignorePermissions"
+        />
+
 </configure>

--- a/ftw/lawgiver/tests/base.py
+++ b/ftw/lawgiver/tests/base.py
@@ -268,10 +268,8 @@ class WorkflowTest(XMLDiffTestCase):
         unmapped = []
         registry = getUtility(IActionGroupRegistry)
 
-        # We use the the workflow_name __unmanaged__ since the permissions
-        # we do not want to manage by default are registered on this fake
-        # workflow so that we can track whether we are not managing them
-        # by intention.
+        explicitly_ignored_permissions = registry.get_ignored_permissions(
+            workflow_name=self.get_name())
 
         for item in self.layer['portal'].ac_inherited_permissions(1):
             permission = item[0]
@@ -282,9 +280,11 @@ class WorkflowTest(XMLDiffTestCase):
                 # e.g. "Public, everyone can access"
                 continue
 
-            if not registry.get_action_group_for_permission(
-                permission, workflow_name='__unmanaged__'):
+            if registry.get_action_group_for_permission(
+                permission, workflow_name=self.get_name()):
+                continue
 
+            if permission not in explicitly_ignored_permissions:
                 unmapped.append(permission)
 
         self.maxDiff = None


### PR DESCRIPTION
"Ignoring" permissions is currently done by mapping the to the `__unmanaged__` action group for the `__unmanaged__` workflow, that's not really nice.
This introduces a `<lawgiver:ignore>` directive for doing that.
Details are in #10 

/cc @maethu 
