### PR TITLE
Support remapping permission per workflow when it is ignored globally.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Support remapping permission per workflow when it is ignored globally. #22
+  [jone]
+
 - **Support for configuring visible roles in sharing view.**
   The specification now allows to define a list of roles which
   should appear one the sharing view.

--- a/ftw/lawgiver/actiongroups.py
+++ b/ftw/lawgiver/actiongroups.py
@@ -57,6 +57,13 @@ class ActionGroupRegistry(object):
         return permission.get(workflow_name, permission.get(None, None))
 
     def get_ignored_permissions(self, workflow_name=None):
-        permissions = set(self._ignores[None])
-        permissions.update(self._ignores[workflow_name])
+        globally_ignored_permissions = set(self._ignores[None])
+        permissions_ignored_by_workflow = set(self._ignores[workflow_name])
+
+        permissions_managed_by_workflow = set(
+            [permission for permission, workflows in self._permissions.items()
+             if workflow_name in workflows])
+
+        permissions = globally_ignored_permissions - permissions_managed_by_workflow
+        permissions.update(permissions_ignored_by_workflow)
         return permissions


### PR DESCRIPTION
Closes #22
/cc @maethu 
