### PR TITLE
make get_role_adapter failsafe if parents are sorted wrong

### DIFF
--- a/ftw/lawgiver/localroles.py
+++ b/ftw/lawgiver/localroles.py
@@ -10,7 +10,7 @@ from zope.i18n import translate
 from zope.interface import Interface
 from zope.interface import implementer
 from zope.interface import implements
-
+from OFS.interfaces import IApplication
 
 DEFAULT_ROLE_TITLES = {
     'Reader': PloneMessageFactory(u"title_can_view", default=u"Can view"),
@@ -28,16 +28,24 @@ class DynamicRolesUtility(object):
 
     @property
     def title(self):
-        return self.get_role_adapter().get_title()
+        role_adapter = self.get_role_adapter()
+        if role_adapter:
+            return role_adapter.get_title()
+        return ''
 
     @property
     def required_permission(self):
-        return self.get_role_adapter().get_required_permission()
+        role_adapter = self.get_role_adapter()
+        if role_adapter:
+            return role_adapter.get_required_permission()
+        return ''
 
     def get_role_adapter(self):
         site = getSite()
         request = site.REQUEST
         context = request.PARENTS[0]
+        if IApplication.providedBy(context):
+            return None
         return getMultiAdapter((context, request),
                                IDynamicRoleAdapter,
                                name=self.plonerole)


### PR DESCRIPTION
:construction: 
@jone we had the issue that the autocomplete widget on the ftw.participation didn't work. When we started debuging we found an AttributeError which most likely stopped the ++widget++ traverser from working properly. Then we walked through the stack and found out that the Exception was raised in lawgiver.

It seems that request.PARENTS isn't always sorted in the same way which ends with the element 0 being the App which of course doesn't have portal_workflow.

This pr just returns None when this is the case but this isn't good imo. Shall we just try and take the last item or give the plonesite as context or is there another way to get my context?
/cc @maethu 
