### PR TITLE
Fix local roles adapter lookup when no traversal happened beforehand.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix local roles adapter lookup when no traversal happened beforehand.
+  This is a rare issue occured because of the context guessing happing
+  in the dynamic role adapter lookup (DynamicRolesUtility.get_role_adapter).
+  [jone]
 
 
 1.2.1 (2013-11-26)

--- a/ftw/lawgiver/localroles.py
+++ b/ftw/lawgiver/localroles.py
@@ -1,3 +1,4 @@
+from OFS.interfaces import IApplication
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory
 from ftw.lawgiver.interfaces import IDynamicRoleAdapter
@@ -38,6 +39,8 @@ class DynamicRolesUtility(object):
         site = getSite()
         request = site.REQUEST
         context = request.PARENTS[0]
+        if IApplication.providedBy(context):
+            context = site
         return getMultiAdapter((context, request),
                                IDynamicRoleAdapter,
                                name=self.plonerole)

--- a/ftw/lawgiver/tests/test_localroles.py
+++ b/ftw/lawgiver/tests/test_localroles.py
@@ -1,0 +1,24 @@
+from plone.app.workflow.interfaces import ISharingPageRole
+from unittest2 import TestCase
+from zope.component import getUtility
+from ftw.lawgiver.testing import LAWGIVER_INTEGRATION_TESTING
+
+
+class TestDynamicRolesUtility(TestCase):
+
+    layer = LAWGIVER_INTEGRATION_TESTING
+
+    def test_role_adapter_context_guessing_with_fallback(self):
+        """The get_role_adapter guesses the context from the traversal
+        stack (request.PARENTS), which might not be set correctly (e.g. in tests) and
+        should fall back to the site root in this case.
+        """
+
+        utility = getUtility(ISharingPageRole, name='Reader')
+        role_adapter = utility.get_role_adapter()
+        self.assertTrue(role_adapter)
+        self.assertEquals(self.layer['portal'], role_adapter.context)
+
+    def test_role_title_when_fallback_necessary(self):
+        utility = getUtility(ISharingPageRole, name='Reader')
+        self.assertEquals('Can view', utility.title.default)


### PR DESCRIPTION
This is a rare issue occured because of the context guessing happing in the dynamic role adapter lookup (DynamicRolesUtility.get_role_adapter).

This an alternative proposal to @Tschanzt 's PR #29 

I'm in favor of this solution because it is more robust and does return results, although the results might not be exactly correct, because the role data (title, permission) is the one effective for the Plone site and not for the actual traversed object.
