### PR TITLE
Fix wrong role title when traversing over views.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
+- Fix wrong role title when traversing over views.
+  [jone]
+
 - Fix local roles adapter lookup when no traversal happened beforehand.
   This is a rare issue occured because of the context guessing happing
   in the dynamic role adapter lookup (DynamicRolesUtility.get_role_adapter).

--- a/ftw/lawgiver/localroles.py
+++ b/ftw/lawgiver/localroles.py
@@ -1,4 +1,7 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
 from OFS.interfaces import IApplication
+from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory
 from ftw.lawgiver.interfaces import IDynamicRoleAdapter
@@ -73,7 +76,14 @@ class DynamicRolesAdapter(object):
 
     def get_local_workflow(self):
         wftool = getToolByName(self.context, 'portal_workflow')
-        workflows = wftool.getWorkflowsFor(self.context)
+
+        context = self.context
+        while context and not IContentish.providedBy(context):
+            context = aq_parent(aq_inner(context))
+        if not context:
+            return None
+
+        workflows = wftool.getWorkflowsFor(context)
         if len(workflows) == 0:
             return None
         else:

--- a/ftw/lawgiver/tests/test_sharing.py
+++ b/ftw/lawgiver/tests/test_sharing.py
@@ -1,12 +1,14 @@
 from Products.CMFCore.utils import getToolByName
 from ftw.builder import Builder
 from ftw.builder import create
+from ftw.lawgiver.interfaces import IDynamicRoleAdapter
 from ftw.lawgiver.testing import SPECIFICATIONS_FUNCTIONAL
 from ftw.lawgiver.tests.pages import Sharing
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
 from unittest2 import TestCase
+from zope.component import getMultiAdapter
 
 
 class TestSharingRoleTranslation(TestCase):
@@ -36,3 +38,19 @@ class TestSharingRoleTranslation(TestCase):
         self.assertEquals(
             ['Can add', 'Can view', 'editor', 'editor-in-chief'],
             Sharing().role_labels)
+
+    def test_custom_role_translation_per_workflow_when_context_is_view(self):
+        # Dependenging on what is traversed, the role utility may guess
+        # the view from the request as context.
+        applyProfile(self.portal, 'ftw.lawgiver.tests:role-translation')
+        wftool = getToolByName(self.portal, 'portal_workflow')
+        wftool.setChainForPortalTypes(['Document'], 'role-translation')
+
+        document = create(Builder('document'))
+        view = document.restrictedTraverse('folder_contents')
+
+        adapter = getMultiAdapter((view, document.REQUEST),
+                                  IDynamicRoleAdapter,
+                                  name='Reader')
+        self.assertEquals('role-translation--ROLE--Reader',
+                          adapter.get_title())


### PR DESCRIPTION
When traversing over view, the dynamic role adapter tries to get the workflow from the view instead of the context,
which causes the title to fallback to the Plone standard translation.

This PR fixes this by walking up the acquisition chain and searching the first `IContentish` object, using this as context.

/cc @maethu 
