### PR TITLE
Fix action group translations for default action groups.

### DIFF
--- a/ftw/lawgiver/generator.py
+++ b/ftw/lawgiver/generator.py
@@ -296,10 +296,9 @@ class WorkflowGenerator(object):
             self.workflow_id)
 
         lang_code = self.specification.language.code
-        translated_action_groups = dict([
-                (translate(name, target_language=lang_code).encode('utf-8'),
-                 name)
-                for name in action_groups])
+        translated_action_groups = dict(
+            [(self._translate_action_group(name, lang_code), name)
+             for name in action_groups])
 
         for customer_role, action in statements:
             if self._find_transition_by_title(action):
@@ -372,6 +371,15 @@ class WorkflowGenerator(object):
                     self.specification.role_mapping[base_role]))
 
         return result
+
+    def _translate_action_group(self, action_group, language):
+        zcml_domain = translate(action_group, target_language=language)
+        if zcml_domain != action_group:
+            return zcml_domain.encode('utf-8')
+        else:
+            return translate(unicode(action_group),
+                             domain='ftw.lawgiver',
+                             target_language=language).encode('utf-8')
 
 
 def resolve_inherited_roles(roles, role_inheritance):

--- a/ftw/lawgiver/testing.py
+++ b/ftw/lawgiver/testing.py
@@ -39,6 +39,24 @@ class LawgiverLayer(PloneSandboxLayer):
     defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
+        # The first definition of an action group defines the the
+        # translation domain - and we cant control ZCML load order.
+        # ftw.lawgiver needs to make sure that the default action groups are
+        # translated in the ftw.lawgiver domain at least as fallback.
+        # For producing this error we add an action group before loading
+        # our ZCML.
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope"'
+            '           xmlns:lawgiver="http://namespaces.zope.org/lawgiver"'
+            '           xmlns:i18n="http://namespaces.zope.org/i18n"'
+            '           i18n_domain="ftw.contentpage">'
+            '  <include package="ftw.lawgiver" file="meta.zcml" />'
+            '  <lawgiver:map_permissions'
+            '      action_group="add"'
+            '      permissions="Add some type" />'
+            '</configure>',
+            context=configurationContext)
+
         xmlconfig.string(
             '<configure xmlns="http://namespaces.zope.org/zope">'
             '  <include package="z3c.autoinclude" file="meta.zcml" />'

--- a/ftw/lawgiver/tests/test_translations.py
+++ b/ftw/lawgiver/tests/test_translations.py
@@ -22,7 +22,9 @@ class TestActionGroupTranslations(TestCase):
                 continue
 
             untranslated[lang] = [name for name in groups
-                                  if translate(name, target_language=lang) == name]
+                                  if translate(unicode(name),
+                                               target_language=lang,
+                                               domain='ftw.lawgiver') == name]
             expected[lang] = []
 
         self.assertEquals(


### PR DESCRIPTION
When a package, which extends default action groups, is loaded before lawgiver, it might define the action group in translation domain other than "ftw.lawgiver", resulting in an untranslated action group.

This adds a fallback to the "ftw.lawgiver" domain if the action group is not translated in its default domain.

@maethu @deiferni 
