### PR TITLE
Sharing role overlay: fix wrong javascript selector for ftw.permissionmanager

### DIFF
--- a/ftw/lawgiver/browser/resources/sharing.js
+++ b/ftw/lawgiver/browser/resources/sharing.js
@@ -1,22 +1,23 @@
 jQuery(function($){
 
-  $('body.template-sharing').
-      find('table#user-group-sharing th, table#current-user-group-sharing th').slice(1).each(function() {
-        var $th = $(this);
-        var role = $.trim($th.text());
-        var url = location.href.concat(
-            '/lawgiver-sharing-describe-role?role='.concat(
+  var setup_overlay = function() {
+    var $th = $(this);
+    var role = $.trim($th.text());
+    var url = location.href.concat(
+        '/lawgiver-sharing-describe-role?role='.concat(
             encodeURIComponent(role)));
-        var $link = $('<a>', {
-          text: role,
-          href: url});
-        $th.html($link);
+    var $link = $('<a>', {
+      text: role,
+      href: url});
+    $th.html($link);
 
-        $link.prepOverlay({
-          subtype: 'ajax',
-          noform: function(el) {return $.plonepopups.noformerrorshow(el, 'close');}
-        });
+    $link.prepOverlay({
+      subtype: 'ajax',
+      noform: function(el) {return $.plonepopups.noformerrorshow(el, 'close');}
+    });
+  };
 
-      });
+  $('body.template-sharing').find('table#current-user-group-sharing th').slice(1).each(setup_overlay);
+  $('body.template-sharing').find('table#user-group-sharing th').slice(1).each(setup_overlay);
 
 });


### PR DESCRIPTION
The problem was that all <th> tags were sliced (first removed), but this included both tables.
This change makes slicing per table and separate setups so that the name column of the second
table is not linked.

Also refactored overlay setup into separate function.

![bildschirmfoto 2014-05-08 um 09 10 50](https://cloud.githubusercontent.com/assets/7469/2912760/38e8cfaa-d680-11e3-8315-c2e2ed981cc7.png)
@maethu @deiferni 
