### PR TITLE
Sharing view: include general statements in role description

### DIFF
--- a/ftw/lawgiver/browser/sharing.py
+++ b/ftw/lawgiver/browser/sharing.py
@@ -117,8 +117,9 @@ class SharingDescribeRole(BrowserView):
 
             role_inheritance = merge_role_inheritance(spec, status)
             ploneroles = get_roles_inherited_by(ploneroles, role_inheritance)
+            statements = spec.generals + status.statements
 
-            for statement_spec_role, action_group in status.statements:
+            for statement_spec_role, action_group in statements:
                 statement_plone_role = spec.role_mapping[statement_spec_role]
                 if statement_plone_role not in ploneroles:
                     continue

--- a/ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+++ b/ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
@@ -31,6 +31,7 @@ editor-in-chief role description:
 
 General:
   An editor can perform the same actions as Everyone.
+  An editor can always add new content.
   An administrator can always view the content
   An administrator can always edit the content
   An administrator can always delete the content
@@ -44,7 +45,6 @@ Status Private:
   An editor can view this content.
   An editor can edit this content.
   An editor can delete this content.
-  An editor can add new content.
   An editor can submit for publication.
   An editor-in-chief can view this content.
   An editor-in-chief can edit this content.
@@ -54,7 +54,6 @@ Status Private:
 
 Status Pending:
   An editor can view this content.
-  An editor can add new content.
   An editor can retract.
   An editor-in-chief can view this content.
   An editor-in-chief can edit this content.
@@ -65,6 +64,5 @@ Status Pending:
 
 Status Published:
   Everyone can view this content.
-  An editor can add new content.
   An editor can retract this content.
   An editor-in-chief can perform the same actions as an editor.

--- a/ftw/lawgiver/tests/test_sharing_describe_roles.py
+++ b/ftw/lawgiver/tests/test_sharing_describe_roles.py
@@ -68,6 +68,19 @@ class TestSharingDescribeRoles(TestCase):
                        'Published': ''}, table)
 
     @browsing
+    def test_permissions_from_general_statements_are_included(self, browser):
+        page = create(Builder('page'))
+        browser.login().visit(page,
+                              view='lawgiver-sharing-describe-role',
+                              data={'role': 'editor'})
+        table = browser.css('table').first.dicts()
+
+        self.assertIn({'Action': 'Add',
+                       'Private': TICK,
+                       'Pending': TICK,
+                       'Published': TICK}, table)
+
+    @browsing
     def test_transitions_are_shown_per_status(self, browser):
         page = create(Builder('page'))
         browser.login().visit(page,


### PR DESCRIPTION
The role description overlay does currently not include general statements.
This changes this behavior to include general statements.

Also changed the specification so that the general statement inheritance test actually does test inheritance from general statements and not from status statements.

@maethu 
