### PR TITLE
Fix definition.xml pretty printing on OSX Mavericks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix definition.xml pretty printing on OSX Mavericks.
+  On Mavericks most of the definition.xml was writte onto a single line.
+  [jone]
 
 
 1.3.0 (2014-05-19)

--- a/ftw/lawgiver/generator.py
+++ b/ftw/lawgiver/generator.py
@@ -332,6 +332,7 @@ class WorkflowGenerator(object):
     def _add_variables(self, doc):
         # The variables are static - we use always the same.
         for node in html.fragments_fromstring(VARIABLES):
+            node.tail = None
             doc.append(node)
 
     def _transition_id(self, transition):


### PR DESCRIPTION
On Mavericks most of the definition.xml was writte onto a single line.

Removing the tail of staticly inserted nodes fixes this issue because it seems to change
the behavior of pretty printing in newer libxml2 versions.

@maethu @elioschmutz 
Fixes #28 
