### PR TITLE
Extract role translation functions into utils.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
+- Extract `generate_role_translation_id` and `translate_role_for_workflow`
+  into utils.
+  [jone]
+
 - Fix definition.xml pretty printing on OSX Mavericks.
   On Mavericks most of the definition.xml was writte onto a single line.
   [jone]

--- a/ftw/lawgiver/generator.py
+++ b/ftw/lawgiver/generator.py
@@ -1,6 +1,7 @@
 from ftw.lawgiver.interfaces import IActionGroupRegistry
 from ftw.lawgiver.interfaces import IPermissionCollector
 from ftw.lawgiver.interfaces import IWorkflowGenerator
+from ftw.lawgiver.utils import generate_role_translation_id
 from ftw.lawgiver.utils import get_roles_inheriting_from
 from ftw.lawgiver.utils import merge_role_inheritance
 from ftw.lawgiver.variables import VARIABLES
@@ -347,8 +348,7 @@ class WorkflowGenerator(object):
             self.workflow_id, self._normalize(status.title))
 
     def _role_id(self, role):
-        return '%s--ROLE--%s' % (self.workflow_id,
-                                 getattr(role, 'original', role))
+        return generate_role_translation_id(self.workflow_id, role)
 
     def _role_description_id(self, role):
         return '%s--ROLE-DESCRIPTION--%s' % (

--- a/ftw/lawgiver/tests/test_utils.py
+++ b/ftw/lawgiver/tests/test_utils.py
@@ -2,10 +2,13 @@ from Products.CMFCore.utils import getToolByName
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.lawgiver.testing import SPECIFICATIONS_FUNCTIONAL
+from ftw.lawgiver.utils import generate_role_translation_id
 from ftw.lawgiver.utils import get_specification
 from ftw.lawgiver.utils import get_specification_for
 from ftw.lawgiver.utils import get_workflow_for
+from ftw.lawgiver.utils import translate_role_for_workflow
 from ftw.lawgiver.wdl.interfaces import ISpecification
+from ftw.lawgiver.wdl.parser import LowerCaseString
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
@@ -65,3 +68,26 @@ class TestUtils(TestCase):
 
     def test_get_specification_for_non_managed_object(self):
         self.assertIsNone(get_specification_for(self.portal))
+
+    def test_generate_role_translation_id(self):
+        self.assertEqual(
+            'wf-foo--ROLE--Editor',
+            generate_role_translation_id('wf-foo', 'Editor'))
+
+    def test_generate_role_translation_id_with_lowercase_string(self):
+        self.assertEqual(
+            'wf-foo--ROLE--Editor',
+            generate_role_translation_id('wf-foo',
+                                         LowerCaseString('Editor')))
+
+    def test_translate_role_for_workflow(self):
+        msgid = translate_role_for_workflow(
+            'wf-foo', LowerCaseString('Editor'))
+
+        self.assertEqual('plone', msgid.domain)
+        self.assertEqual('wf-foo--ROLE--Editor', str(msgid))
+
+        fallback = msgid.default
+        self.assertEqual('plone', fallback.domain)
+        self.assertEqual('title_can_edit', str(fallback))
+        self.assertEqual('Can edit', fallback.default)


### PR DESCRIPTION
- ftw.lawgiver.utils.generate_role_translation_id
- ftw.lawgiver.utils.translate_role_for_workflow

@maethu 
