### PR TITLE
i18n generator: escape quotes in generated message strings.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- i18n generator: escape quotes in generated message strings.
+  [jone]
 
 
 1.3.1 (2014-05-28)

--- a/ftw/lawgiver/i18nbuilder.py
+++ b/ftw/lawgiver/i18nbuilder.py
@@ -100,8 +100,8 @@ class I18nBuilder(object):
             catalog.keys())
 
         for msgid, msgstr in translations.items():
-            msgid = msgid.decode('utf-8')
-            msgstr = msgstr.decode('utf-8')
+            msgid = msgid.decode('utf-8').replace('"', '\\"')
+            msgstr = msgstr.decode('utf-8').replace('"', '\\"')
 
             if msgid in delete_candidates:
                 delete_candidates.remove(msgid)

--- a/ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
+++ b/ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
@@ -4,5 +4,8 @@ Initial Status: Private
 Role mapping:
   editor => Editor
 
+Editor role description:
+  An "Editor" writes articles.
+
 Status Private:
   An editor can view this content.

--- a/ftw/lawgiver/tests/test_i18nbuilder.py
+++ b/ftw/lawgiver/tests/test_i18nbuilder.py
@@ -20,6 +20,9 @@ SIMPLE_WORKFLOW_MESSAGES = r'''
 msgid "simple_workflow--ROLE--Editor"
 msgstr "editor"
 
+msgid "simple_workflow--ROLE-DESCRIPTION--Editor"
+msgstr "An \"Editor\" writes articles."
+
 msgid "simple_workflow--STATUS--private"
 msgstr "Private"
 '''.strip()
@@ -89,6 +92,7 @@ class TestI18nBuilder(TestCase):
 
     def test_generate_pot_generates_pot_file(self):
         I18nBuilder(self.simple_workflow_spec_path).generate_pot()
+        self.maxDiff = None
         self.assertMultiLineEqual(
             clear_msgstr(PO_HEADER + '\n\n' +
                          SIMPLE_WORKFLOW_MESSAGES + '\n'),
@@ -176,4 +180,4 @@ def read_file(path):
 
 
 def clear_msgstr(text):
-    return re.sub(r'msgstr "[^"]*"', 'msgstr ""', text)
+    return re.sub(r'msgstr ".*"$', 'msgstr ""', text, flags=re.M)


### PR DESCRIPTION
Fixes quote character escaping in generated translation messages, e.g. role descriptions.
Closes #51 
