### PR TITLE
Add support for assigning permissions to multiple action groups.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,40 @@ This can be easily achieved by also defining the workflow in the ZCML:
     </configure>
 
 
+Assigning permission to multiple action groups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes, a permission should be assigned to multiple action groups.
+This can be done with the ``move`` attribute of the ``map_permissions`` directive.
+Just make sure that all other ``map_permissions`` ZCMLs are loaded before doing that,
+especially the default ``lawgiver.zcml`` of ``ftw.lawgiver``.
+
+.. code:: xml
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
+        i18n_domain="my.package">
+
+        <include package="ftw.lawgiver" />
+
+        <lawgiver:map_permissions
+            action_group="add ticket"
+            permissions="my.package: Add Ticket"
+            workflow="my_workflow"
+            />
+
+        <lawgiver:map_permissions
+            action_group="add ticket"
+            permissions="Add portal content"
+            workflow="my_workflow"
+            move="False"
+            />
+
+    </configure>
+
+
+
 The workflow specification
 --------------------------
 

--- a/ftw/lawgiver/actiongroups.py
+++ b/ftw/lawgiver/actiongroups.py
@@ -9,14 +9,18 @@ class ActionGroupRegistry(object):
 
     def __init__(self):
         self._permissions = {}
+        self._extending_permissions = {}
         self._ignores = defaultdict(set)
 
-    def update(self, action_group, permissions, workflow=None):
-        for perm in permissions:
-            if perm not in self._permissions:
-                self._permissions[perm] = {}
-
-            self._permissions[perm][workflow] = action_group
+    def update(self, action_group, permissions, workflow=None, move=True):
+        if move:
+            for permission in permissions:
+                self._update_default_permission(
+                    permission, workflow, action_group)
+        else:
+            for permission in permissions:
+                self._update_extending_permissions(
+                    permission, workflow, action_group)
 
     def ignore(self, permissions, workflow=None):
         self._ignores[workflow].update(permissions)
@@ -26,7 +30,7 @@ class ActionGroupRegistry(object):
 
         ignored_permissions = self.get_ignored_permissions(workflow_name)
 
-        for permission, workflows in self._permissions.items():
+        for permission, workflows in self._merged_permissions().items():
             if permission in ignored_permissions:
                 continue
 
@@ -37,34 +41,86 @@ class ActionGroupRegistry(object):
             else:
                 continue
 
-            group = workflows[wfname]
-            if group not in result:
-                result[group] = set()
-
-            result[group].add(permission)
+            for group in workflows[wfname]:
+                if group not in result:
+                    result[group] = set()
+                result[group].add(permission)
 
         return result
 
-    def get_action_group_for_permission(self, permission_title,
-                                        workflow_name=None):
-        if permission_title not in self._permissions:
-            return None
+    def get_action_groups_for_permission(self, permission_title,
+                                         workflow_name=None):
+        if permission_title not in self._merged_permissions():
+            return []
 
         if permission_title in self.get_ignored_permissions(workflow_name):
-            return None
+            return []
 
-        permission = self._permissions[permission_title]
-        return permission.get(workflow_name, permission.get(None, None))
+        permission = self._merged_permissions()[permission_title]
+        return permission.get(workflow_name, permission.get(None, []))
 
     def get_ignored_permissions(self, workflow_name=None):
         globally_ignored_permissions = set(self._ignores[None])
         permissions_ignored_by_workflow = set(self._ignores[workflow_name])
 
         permissions_managed_by_workflow = set(
-            [permission for permission, workflows in self._permissions.items()
+            [permission for permission, workflows
+             in self._merged_permissions().items()
              if workflow_name in workflows])
 
         permissions = (globally_ignored_permissions
                        - permissions_managed_by_workflow)
         permissions.update(permissions_ignored_by_workflow)
         return permissions
+
+    def _update_default_permission(self, permission, workflow, action_group):
+        if permission not in self._permissions:
+            self._permissions[permission] = {}
+
+        self._permissions[permission][workflow] = action_group
+
+    def _update_extending_permissions(self, permission, workflow,
+                                      action_group):
+        if permission not in self._extending_permissions:
+            self._extending_permissions[permission] = {}
+
+        if workflow in self._extending_permissions[permission]:
+            self._extending_permissions[permission][workflow].append(
+                action_group)
+        else:
+            self._extending_permissions[permission][workflow] = [action_group]
+
+    def _merged_permissions(self):
+        result = {}
+        for permission in set(self._permissions.keys() +
+                              self._extending_permissions.keys()):
+            result[permission] = (
+                self._merged_action_groups_mapping_for_perm(permission))
+
+        return result
+
+    def _merged_action_groups_mapping_for_perm(self, permission):
+        workflows = set(self._permissions.get(permission, {}).keys() +
+                        self._extending_permissions.get(permission, {}).keys())
+        result = {}
+        for workflow in workflows:
+            result[workflow] = self._merged_action_groups_for_perm_in_wf(
+                permission, workflow)
+        return result
+
+    def _merged_action_groups_for_perm_in_wf(self, permission, workflow):
+        result = []
+
+        default_perm_info = self._permissions.get(permission, {})
+        if workflow in default_perm_info:
+            result.append(default_perm_info[workflow])
+        elif None in default_perm_info:
+            result.append(default_perm_info[None])
+
+        extending_perm_info = self._extending_permissions.get(permission, {})
+        if workflow in extending_perm_info:
+            result.extend(extending_perm_info[workflow])
+        elif None in extending_perm_info:
+            result.extend(extending_perm_info[None])
+
+        return result

--- a/ftw/lawgiver/collector.py
+++ b/ftw/lawgiver/collector.py
@@ -13,25 +13,23 @@ class DefaultPermissionCollector(object):
         grouped = self.get_grouped_permissions(workflow_name)
         if not grouped:
             return []
-        return sorted(reduce(list.__add__, grouped.values()))
+        return sorted(set(reduce(list.__add__, grouped.values())))
 
     def get_grouped_permissions(self, workflow_name, unmanaged=False):
         registry = getUtility(IActionGroupRegistry)
         result = {}
 
         for perm in self._get_permissions():
-            action_group = registry.get_action_group_for_permission(
+            action_groups = registry.get_action_groups_for_permission(
                 perm, workflow_name=workflow_name)
-            if action_group is None and not unmanaged:
-                continue
 
-            elif action_group is None:
-                action_group = 'unmanaged'
+            if unmanaged and not action_groups:
+                action_groups = ['unmanaged']
 
-            if action_group not in result:
-                result[action_group] = set()
-
-            result[action_group].add(perm)
+            for action_group in action_groups:
+                if action_group not in result:
+                    result[action_group] = set()
+                result[action_group].add(perm)
 
         for key, value in result.items():
             result[key] = sorted(value)

--- a/ftw/lawgiver/generator.py
+++ b/ftw/lawgiver/generator.py
@@ -275,11 +275,11 @@ class WorkflowGenerator(object):
             return []
 
         agregistry = getUtility(IActionGroupRegistry)
-        action_group = agregistry.get_action_group_for_permission(
+        action_groups = agregistry.get_action_groups_for_permission(
             permission, self.workflow_id)
 
         customer_roles = (role for (role, group) in statements
-                          if group == action_group)
+                          if group in action_groups)
 
         plone_roles = (self.specification.role_mapping[cr]
                        for cr in customer_roles)

--- a/ftw/lawgiver/interfaces.py
+++ b/ftw/lawgiver/interfaces.py
@@ -35,8 +35,8 @@ class IActionGroupRegistry(Interface):
         the value is a list of permissions (string).
         """
 
-    def get_action_group_for_permission(permission_title, workflow_name=None):
-        """Returns the name of the action group a permission is mapped to.
+    def get_action_groups_for_permission(permission_title, workflow_name=None):
+        """Returns the names of the action groups a permission is mapped to.
         Optional the `workflow_name` can be passed to make the query workflow
         specific.
         If the permission is not mapped, None is returned.

--- a/ftw/lawgiver/meta.py
+++ b/ftw/lawgiver/meta.py
@@ -34,6 +34,15 @@ class IMapPermissionsDirective(Interface):
         default=None,
         required=False)
 
+    move = Bool(
+        title=u'Move permissions from original to this action group',
+        description=u'When True (default), the permissions are removed'
+        u' from whether action groups they were mapped before.'
+        u' By setting it to False, permissions can appear in multiple'
+        u' action groups.',
+        default=True,
+        required=False)
+
 
 class IIgnorePermissionsDirective(Interface):
 

--- a/ftw/lawgiver/testing.py
+++ b/ftw/lawgiver/testing.py
@@ -66,6 +66,23 @@ class LawgiverLayer(PloneSandboxLayer):
             '</configure>',
             context=configurationContext)
 
+        # For making sure that having the same permission in multiple action groups
+        # does not break the workflow building, we just create a new action group
+        # with permissions already mapped to "add".
+        # When this breaks the "add" action group, we'd notice it in the example
+        # workflow test.
+        xmlconfig.string(
+            '<configure xmlns="http://namespaces.zope.org/zope"'
+            '           xmlns:lawgiver="http://namespaces.zope.org/lawgiver">'
+            '  <lawgiver:map_permissions'
+            '      action_group="add folders"'
+            '      permissions="Add portal content,'
+            '                   ATContentTypes: Add Folder"'
+            '      move="False"'
+            '      />'
+            '</configure>',
+            context=configurationContext)
+
         z2.installProduct(app, 'ftw.lawgiver')
 
     def setUpPloneSite(self, portal):

--- a/ftw/lawgiver/tests/base.py
+++ b/ftw/lawgiver/tests/base.py
@@ -117,11 +117,12 @@ class BaseTest(MockTestCase, XMLDiffTestCase):
         site = FakeSite()
         setSite(site)
 
-    def map_permissions(self, permissions, action_group, workflow_name=None):
+    def map_permissions(self, permissions, action_group, workflow_name=None, move=True):
         self.load_map_permissions_zcml(
             '<lawgiver:map_permissions',
             '    action_group="%s"' % action_group,
             '    permissions="%s"' % ','.join(permissions),
+            '    move="%s"' % str(move),
             '    %s />' % (
                 workflow_name and 'workflow="%s"' % workflow_name or ''))
 
@@ -289,7 +290,7 @@ class WorkflowTest(XMLDiffTestCase):
                 # e.g. "Public, everyone can access"
                 continue
 
-            if registry.get_action_group_for_permission(
+            if registry.get_action_groups_for_permission(
                 permission, workflow_name=self.get_name()):
                 continue
 

--- a/ftw/lawgiver/tests/test_collector.py
+++ b/ftw/lawgiver/tests/test_collector.py
@@ -129,3 +129,17 @@ class TestDefaultPermissionCollector(BaseTest):
 
         self.assertEquals(['View'],
                           self.collector.collect('bar'))
+
+    def test_get_grouped_permissions_IN_MULTIPLE_GROUPS(self):
+        self.register_permissions(**{
+                'cmf.AddPortalContent': 'Add portal content'})
+
+        self.map_permissions(['Add portal content'], 'add')
+        self.map_permissions(['Add portal content'], 'edit', move=False)
+
+        self.assertEquals({'add': ['Add portal content'],
+                           'edit': ['Add portal content']},
+                          self.collector.get_grouped_permissions('foo'))
+
+        self.assertEquals(['Add portal content'],
+                          self.collector.collect('foo'))

--- a/ftw/lawgiver/tests/test_generator_integration.py
+++ b/ftw/lawgiver/tests/test_generator_integration.py
@@ -52,6 +52,8 @@ class TestGeneratorIntegration(BaseTest):
         self.map_permissions(['Add portal content',
                               'ATContentTypes: Add Image'],
                              'add')
+        self.map_permissions(['Add portal content', 'ATContentTypes: Add Folder'],
+                             'add folder', move=False)
         self.map_permissions(['Access future portal content'], 'view future')
         self.map_permissions(['ATContentTypes: Add Image'], 'edit',
                              workflow_name='my_custom_workflow')

--- a/ftw/lawgiver/tests/test_translations.py
+++ b/ftw/lawgiver/tests/test_translations.py
@@ -27,6 +27,11 @@ class TestActionGroupTranslations(TestCase):
                                                domain='ftw.lawgiver') == name]
             expected[lang] = []
 
+        # The "add folders" is defined in the testing layer just for testing purposes.
+        for untranslated_groups in untranslated.values():
+            if 'add folders' in untranslated_groups:
+                untranslated_groups.remove('add folders')
+
         self.assertEquals(
             expected, untranslated,
             'There action groups which are not translated.')


### PR DESCRIPTION
There are situations when a permission must be mapped to multiple action groups.
For example when having multiple "add" action groups (for adding different types), the "Add portal content" permission should be in each such action groups.

This can now be achieved by using the optional "move" flag (default: True) of the "map_permissions" directive.
When using move="False", the permission is not removed from the original action group but only added to the new one.

// @mbaechtold @maethu 