### PR TITLE
Fix UnicodeDecodeError.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.6.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix UnicodeDecodeError.
+  [mbaechtold]
 
 
 1.6.1 (2015-10-08)

--- a/ftw/lawgiver/i18nbuilder.py
+++ b/ftw/lawgiver/i18nbuilder.py
@@ -151,13 +151,13 @@ class I18nBuilder(object):
                 msg.automatic_comments = filter(
                     lambda text: not text.startswith('Default: '),
                     msg.automatic_comments)
-                msg.automatic_comments.append('Default: "{0}"'.format(msgstr))
+                msg.automatic_comments.append(u'Default: "{0}"'.format(msgstr))
 
             else:
                 catalog.add(msgid, msgstr=msgstr,
                             references=[self.relative_specification_path],
                             automatic_comments=[
-                                'Default: "{0}"'.format(msgstr)])
+                                u'Default: "{0}"'.format(msgstr)])
 
             if is_pot:
                 catalog[msgid].msgstr = u''

--- a/ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
+++ b/ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
@@ -8,7 +8,7 @@ Editor role description:
   An "Editor" writes articles.
 
 Transitions:
-  publish (Private => Published)
+  püblish (Private => Published)
 
 Status Private:
   An editor can view this content.

--- a/ftw/lawgiver/tests/test_i18nbuilder.py
+++ b/ftw/lawgiver/tests/test_i18nbuilder.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from ftw.lawgiver.i18nbuilder import I18nBuilder
 from ftw.lawgiver.testing import LAWGIVER_INTEGRATION_TESTING
 from ftw.lawgiver.tests.helpers import cleanup_path
@@ -27,10 +28,10 @@ msgstr "Private"
 msgid "Published"
 msgstr "Published"
 
-#. Default: "publish"
+#. Default: "püblish"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "publish"
-msgstr "publish"
+msgid "püblish"
+msgstr "püblish"
 
 #. Default: "editor"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt


### PR DESCRIPTION
The error happened if the name of the transition in the definition file contained non-ASCII characters.