### PR TITLE
Map permissions for static portlet and collection portlet.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,9 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- No longer ignore the permissions to add collection portlet and static
+  portlet but rather map them to the existing "manage portlets" action group.
+  [mbaechtold]
 
 
 1.6.2 (2015-11-16)

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -54,6 +54,8 @@
         action_group="manage portlets"
         permissions="
                      Portlets: Manage portlets,
+                     plone.portlet.collection: Add collection portlet,
+                     plone.portlet.static: Add static portlet,
                      "
         />
 
@@ -276,8 +278,6 @@
                      WebDAV access,
                      plone.app.blob: Add Blob,
                      plone.cachepurging: Manually purge objects,
-                     plone.portlet.collection: Add collection portlet,
-                     plone.portlet.static: Add static portlet,
                      plone.resource: Export ZIP file,
                      plone.resourceeditor: Manage Sources,
 

--- a/ftw/lawgiver/tests/assets/example-4.2/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.2/definition.xml
@@ -40,6 +40,8 @@
   <permission>iterate : Check in content</permission>
   <permission>iterate : Check out content</permission>
   <permission>plone.app.collection: Add Collection</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
   <state state_id="example-4.2--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-4.2--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-4.2--TRANSITION--retract--pending_private"/>
@@ -181,6 +183,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <state state_id="example-4.2--STATUS--private" title="Private">
     <exit-transition transition_id="example-4.2--TRANSITION--publish--private_published"/>
@@ -332,6 +336,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <state state_id="example-4.2--STATUS--published" title="Published">
     <exit-transition transition_id="example-4.2--TRANSITION--retract--published_private"/>
@@ -465,6 +471,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <transition new_state="example-4.2--STATUS--published" title="publish" transition_id="example-4.2--TRANSITION--publish--private_published" after_script="" before_script="" trigger="USER">
     <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.2--TRANSITION--publish--private_published">publish</action>

--- a/ftw/lawgiver/tests/assets/example-4.3.4/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.3.4/definition.xml
@@ -41,6 +41,8 @@
   <permission>iterate : Check in content</permission>
   <permission>iterate : Check out content</permission>
   <permission>plone.app.collection: Add Collection</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
   <state state_id="example-4.3.4--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-4.3.4--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-4.3.4--TRANSITION--retract--pending_private"/>
@@ -186,6 +188,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <state state_id="example-4.3.4--STATUS--private" title="Private">
     <exit-transition transition_id="example-4.3.4--TRANSITION--publish--private_published"/>
@@ -342,6 +346,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <state state_id="example-4.3.4--STATUS--published" title="Published">
     <exit-transition transition_id="example-4.3.4--TRANSITION--retract--published_private"/>
@@ -478,6 +484,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <transition new_state="example-4.3.4--STATUS--published" title="publish" transition_id="example-4.3.4--TRANSITION--publish--private_published" after_script="" before_script="" trigger="USER">
     <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.3.4--TRANSITION--publish--private_published">publish</action>

--- a/ftw/lawgiver/tests/assets/example-4.3.5/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.3.5/definition.xml
@@ -41,6 +41,8 @@
   <permission>iterate : Check in content</permission>
   <permission>iterate : Check out content</permission>
   <permission>plone.app.collection: Add Collection</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
   <state state_id="example-4.3.5--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-4.3.5--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-4.3.5--TRANSITION--retract--pending_private"/>
@@ -186,6 +188,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <state state_id="example-4.3.5--STATUS--private" title="Private">
     <exit-transition transition_id="example-4.3.5--TRANSITION--publish--private_published"/>
@@ -342,6 +346,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <state state_id="example-4.3.5--STATUS--published" title="Published">
     <exit-transition transition_id="example-4.3.5--TRANSITION--retract--published_private"/>
@@ -478,6 +484,8 @@
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <transition new_state="example-4.3.5--STATUS--published" title="publish" transition_id="example-4.3.5--TRANSITION--publish--private_published" after_script="" before_script="" trigger="USER">
     <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.3.5--TRANSITION--publish--private_published">publish</action>

--- a/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/definition.xml
+++ b/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/definition.xml
@@ -41,6 +41,8 @@
   <permission>iterate : Check in content</permission>
   <permission>iterate : Check out content</permission>
   <permission>plone.app.collection: Add Collection</permission>
+  <permission>plone.portlet.collection: Add collection portlet</permission>
+  <permission>plone.portlet.static: Add static portlet</permission>
   <state state_id="role-translation--STATUS--default" title="Default">
     <permission-map name="ATContentTypes: Add Document" acquired="False">
       <permission-role>Editor</permission-role>
@@ -213,6 +215,8 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
+    <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
+    <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
   <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
     <description>Previous transition</description>


### PR DESCRIPTION
No longer ignore the permissions `plone.portlet.collection: Add collection portlet` and `plone.portlet.static: Add static portlet` but rather move them to the action group `manage portlets`.