### PR TITLE
Ignore the permissions to access inactive and future content.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 1.6.3 (unreleased)
 ------------------
 
+- Ignore the permissions to access inactive and future content because the
+  portal catalog checks the Plone root for these permissions, not the context.
+  [mbaechtold]
+
 - No longer ignore the permissions to add collection portlet and static
   portlet but rather map them to the existing "manage portlets" action group.
   [mbaechtold]

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -20,15 +20,6 @@
 
 
     <lawgiver:map_permissions
-        action_group="view inactive objects"
-        permissions="
-                     Access future portal content,
-                     Access inactive portal content,
-                     "
-        />
-
-
-    <lawgiver:map_permissions
         action_group="edit"
         permissions="
                      CMFEditions: Access previous versions,
@@ -119,7 +110,6 @@
 
     <lawgiver:ignore
         permissions="
-
                      ATContentTypes Topic: Add ATBooleanCriterion,
                      ATContentTypes Topic: Add ATCurrentAuthorCriterion,
                      ATContentTypes Topic: Add ATDateCriteria,
@@ -137,6 +127,8 @@
                      ATContentTypes: View history,
                      Access Transient Objects,
                      Access arbitrary user session data,
+                     Access future portal content,
+                     Access inactive portal content,
                      Access session data,
                      Add ATContentTypes tools,
                      Add Archetypes Tools,

--- a/ftw/lawgiver/tests/assets/example-4.2/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.2/definition.xml
@@ -9,8 +9,6 @@
   <permission>ATContentTypes: Add Link</permission>
   <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
-  <permission>Access future portal content</permission>
-  <permission>Access inactive portal content</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
   <permission>Add portal events</permission>
@@ -83,8 +81,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -226,8 +222,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -379,8 +373,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>

--- a/ftw/lawgiver/tests/assets/example-4.3.4/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.3.4/definition.xml
@@ -9,8 +9,6 @@
   <permission>ATContentTypes: Add Link</permission>
   <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
-  <permission>Access future portal content</permission>
-  <permission>Access inactive portal content</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
   <permission>Add portal events</permission>
@@ -84,8 +82,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -231,8 +227,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -389,8 +383,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>

--- a/ftw/lawgiver/tests/assets/example-4.3.5/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.3.5/definition.xml
@@ -9,8 +9,6 @@
   <permission>ATContentTypes: Add Link</permission>
   <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
-  <permission>Access future portal content</permission>
-  <permission>Access inactive portal content</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
   <permission>Add portal events</permission>
@@ -84,8 +82,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -231,8 +227,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -389,8 +383,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>

--- a/ftw/lawgiver/tests/assets/example.definition.xml
+++ b/ftw/lawgiver/tests/assets/example.definition.xml
@@ -2,7 +2,6 @@
 <dc-workflow workflow_id="my_custom_workflow" title="My Custom Workflow" description="A three state publication workflow" state_variable="review_state" initial_state="my_custom_workflow--STATUS--private" manager_bypass="True">
  <permission>ATContentTypes: Add Image</permission>
  <permission>Access contents information</permission>
- <permission>Access future portal content</permission>
  <permission>Add portal content</permission>
  <permission>Delete objects</permission>
  <permission>Modify portal content</permission>
@@ -19,8 +18,6 @@
    <permission-role>Editor</permission-role>
    <permission-role>Site Administrator</permission-role>
    <permission-role>Reviewer</permission-role>
-  </permission-map>
-  <permission-map name="Access future portal content" acquired="False">
   </permission-map>
   <permission-map name="Add portal content" acquired="False">
    <permission-role>Editor</permission-role>
@@ -53,8 +50,6 @@
    <permission-role>Site Administrator</permission-role>
    <permission-role>Reviewer</permission-role>
   </permission-map>
-  <permission-map name="Access future portal content" acquired="False">
-  </permission-map>
   <permission-map name="Add portal content" acquired="False">
    <permission-role>Editor</permission-role>
    <permission-role>Reviewer</permission-role>
@@ -85,8 +80,6 @@
    <permission-role>Editor</permission-role>
    <permission-role>Site Administrator</permission-role>
    <permission-role>Reviewer</permission-role>
-  </permission-map>
-  <permission-map name="Access future portal content" acquired="False">
   </permission-map>
   <permission-map name="Add portal content" acquired="False">
    <permission-role>Editor</permission-role>

--- a/ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/definition.xml
+++ b/ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/definition.xml
@@ -9,8 +9,6 @@
   <permission>ATContentTypes: Add Link</permission>
   <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
-  <permission>Access future portal content</permission>
-  <permission>Access inactive portal content</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
   <permission>Add portal events</permission>
@@ -82,8 +80,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -245,8 +241,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -418,8 +412,6 @@
       <permission-role>Reviewer</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>

--- a/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/definition.xml
+++ b/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/definition.xml
@@ -9,8 +9,6 @@
   <permission>ATContentTypes: Add Link</permission>
   <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
-  <permission>Access future portal content</permission>
-  <permission>Access inactive portal content</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
   <permission>Add portal events</permission>
@@ -89,8 +87,6 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>

--- a/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/result.xml
+++ b/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/result.xml
@@ -9,8 +9,6 @@
   <permission>ATContentTypes: Add Link</permission>
   <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
-  <permission>Access future portal content</permission>
-  <permission>Access inactive portal content</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
   <permission>Add portal events</permission>
@@ -84,8 +82,6 @@
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
     </permission-map>
-    <permission-map name="Access future portal content" acquired="False"/>
-    <permission-map name="Access inactive portal content" acquired="False"/>
     <permission-map name="Add Folders" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>


### PR DESCRIPTION
These permissions cannot be managed because the portal catalog checks the Plone root for these permissions, not the context.

Closes https://github.com/4teamwork/ftw.lawgiver/issues/27.