### PR TITLE
Add plone.app.contenttypes permissions to lawgiver.zcml.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,10 @@ Changelog
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add plone.app.contenttypes permissions to lawgiver.zcml.
+  Since plone.app.contenttypes is standard Plone we add the
+  plone.app.contenttypes mapping to the lawgiver.zcml.
+  [elioschmutz]
 
 
 1.7.0 (2016-05-02)

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -54,7 +54,6 @@
     <lawgiver:map_permissions
         action_group="add"
         permissions="
-
                      ATContentTypes: Add Document,
                      ATContentTypes: Add Event,
                      ATContentTypes: Add File,
@@ -71,7 +70,14 @@
                      Delete objects,
                      PloneFormGen: Add Content,
                      plone.app.collection: Add Collection,
-
+                     plone.app.contenttypes: Add Collection,
+                     plone.app.contenttypes: Add Document,
+                     plone.app.contenttypes: Add Event,
+                     plone.app.contenttypes: Add File,
+                     plone.app.contenttypes: Add Folder,
+                     plone.app.contenttypes: Add Image,
+                     plone.app.contenttypes: Add Link,
+                     plone.app.contenttypes: Add News Item
                      "
         />
 


### PR DESCRIPTION
Since plone.app.contenttypes is standard Plone we add the plone.app.contenttypes mapping to the lawgiver.zcml.

see also https://github.com/4teamwork/ftw.bob.templates/issues/22

closes #66 