### PR TITLE
rebuild specs with upgrade step

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Added control panel button for rebuilding specifications and creating an upgrade step. [jone]
 
 
 1.8.0 (2016-06-30)

--- a/ftw/lawgiver/browser/speclisting.py
+++ b/ftw/lawgiver/browser/speclisting.py
@@ -16,6 +16,11 @@ class ListSpecifications(BrowserView):
             updater.update_all_specifications(
                 output_formatter=StatusMessageFormatter(self.request))
 
+        if 'update_all_specifications_with_upgradestep' in self.request.form:
+            updater = getUtility(IUpdater)
+            updater.update_all_specifications_with_upgrade_step(
+                output_formatter=StatusMessageFormatter(self.request))
+
         return super(ListSpecifications, self).__call__()
 
     def specifications(self):

--- a/ftw/lawgiver/browser/templates/speclisting.pt
+++ b/ftw/lawgiver/browser/templates/speclisting.pt
@@ -58,6 +58,15 @@
               are skipped.
             </p>
 
+            <input type="submit"
+                   i18n:attributes="value button_update_specs_with_upgradestep"
+                   name="update_all_specifications_with_upgradestep"
+                   value="Update all specifications with upgradestep" />
+
+            <p class="discreet" i18n:translate="description_update_specs_with_upgradestep">
+                Update specifications and create an upgrade step with ftw.upgrade.
+            </p>
+
           </form>
         </fieldset>
 

--- a/ftw/lawgiver/exceptions.py
+++ b/ftw/lawgiver/exceptions.py
@@ -3,3 +3,8 @@
 class ParsingError(Exception):
     """An error occured while parsing the specification.
     """
+
+
+class UpgradeStepCreationError(Exception):
+    """Error while creating an upgrade step.
+    """

--- a/ftw/lawgiver/locales/de/LC_MESSAGES/ftw.lawgiver.po
+++ b/ftw/lawgiver/locales/de/LC_MESSAGES/ftw.lawgiver.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-02 08:57+0000\n"
+"POT-Creation-Date: 2017-01-01 11:45+0000\n"
 "PO-Revision-Date: 2014-09-08 12:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -134,6 +134,11 @@ msgstr "Übersetzung in locales-Verzeichnis aktualisieren"
 msgid "button_update_security"
 msgstr "Sicherheit aktualisieren"
 
+#. Default: "Update all specifications with upgradestep"
+#: ./ftw/lawgiver/browser/templates/speclisting.pt:61
+msgid "button_update_specs_with_upgradestep"
+msgstr "Alle Spezifikationen aktualisieren und Upgrade Step erstellen"
+
 #. Default: "Write and Import Workflow"
 #: ./ftw/lawgiver/browser/templates/details.pt:103
 msgid "button_write_and_import"
@@ -168,6 +173,11 @@ msgstr "Aktualisiert Übersetzungs-Dateien ${pot-name} und ${po-name} in dem loc
 msgid "description_update_security"
 msgstr "Der Button \"${button_title}\" aktualisiert die Sicherheitseinstellungen aller (!) objekte auf dieser Plone-Seite. Dies ist der gleiche Button wie der \"Update security settings\" in portal_workflow."
 
+#. Default: "Update specifications and create an upgrade step with ftw.upgrade."
+#: ./ftw/lawgiver/browser/templates/speclisting.pt:66
+msgid "description_update_specs_with_upgradestep"
+msgstr "Spezifikationen aktualiseren und einen Upgrade Step erstellen. Dies benötigt ein registriertes ftw.upgrade upgrade-step:directory mit dem Name \"upgrades\"."
+
 #. Default: "When the \"${button_title}\" button is clicked the workflow is generated and written to the <i title=\"${DYNAMIC_CONTENT}\">definition.xml</i> and then the workflow is imported using Generic Setup."
 #: ./ftw/lawgiver/browser/templates/details.pt:121
 msgid "description_write_and_import"
@@ -184,12 +194,12 @@ msgstr "bearbeiten"
 
 #. Default: "${id}: The specification file could not be parsed: ${error}"
 #: ./ftw/lawgiver/browser/details.py:187
-#: ./ftw/lawgiver/updater.py:133
+#: ./ftw/lawgiver/updater.py:197
 msgid "error_parsing_error"
 msgstr "${id}: Die Datei mit der Workflow-Spezifikation konnte nicht gelesen werden: ${error}"
 
 #. Default: "${id}: Error while generating the workflow: ${msg}"
-#: ./ftw/lawgiver/updater.py:81
+#: ./ftw/lawgiver/updater.py:145
 msgid "error_while_generating_workflow"
 msgstr "${id}: Fehler beim generieren des Workflows: ${msg}"
 
@@ -198,7 +208,7 @@ msgid "ftw.lawgiver"
 msgstr "ftw.lawgiver"
 
 #. Default: "${id}: The translations were updated in your locales directory. You should now run bin/i18n-build"
-#: ./ftw/lawgiver/updater.py:112
+#: ./ftw/lawgiver/updater.py:176
 msgid "info_locales_updated"
 msgstr "${id}: Die Übersetzungen wurden im locales-Verzeichnis aktualisert. Jetzt sollt bin/i18n-build ausgeführt werden."
 
@@ -208,7 +218,7 @@ msgid "info_security_updated"
 msgstr "Sicherheitsupdate: ${amount} Objekte wurden aktualisiert."
 
 #. Default: "${id}: The workflow was generated to ${path}."
-#: ./ftw/lawgiver/updater.py:94
+#: ./ftw/lawgiver/updater.py:158
 msgid "info_workflow_generated"
 msgstr "${id}: Der Workflow wurde generiert: ${path}."
 
@@ -257,7 +267,7 @@ msgid "view inactive objects"
 msgstr "inaktive Inhalte ansehen"
 
 #. Default: "${id}: Skipping released specification."
-#: ./ftw/lawgiver/updater.py:51
+#: ./ftw/lawgiver/updater.py:69
 msgid "warning_skipped_released_spec"
 msgstr "${id}: Package bereits released, Workflow wurde nicht aktualisiert."
 
@@ -265,4 +275,3 @@ msgstr "${id}: Package bereits released, Workflow wurde nicht aktualisiert."
 #: ./ftw/lawgiver/browser/templates/details.pt:103
 msgid "warning_workflow_not_installed"
 msgstr "Der Workflow ${workflow} ist noch nicht installiert. Wenn der Workflow mit dem Button \"${button_title}\" installiert wird die Workflow Policy nicht angepasst, d.H. kein Typ wird diesen Workflow automatisch benutzen."
-

--- a/ftw/lawgiver/locales/ftw.lawgiver.pot
+++ b/ftw/lawgiver/locales/ftw.lawgiver.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2016-05-02 08:57+0000\n"
+"POT-Creation-Date: 2017-01-01 11:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -137,6 +137,11 @@ msgstr ""
 msgid "button_update_security"
 msgstr ""
 
+#. Default: "Update all specifications with upgradestep"
+#: ./ftw/lawgiver/browser/templates/speclisting.pt:61
+msgid "button_update_specs_with_upgradestep"
+msgstr ""
+
 #. Default: "Write and Import Workflow"
 #: ./ftw/lawgiver/browser/templates/details.pt:103
 msgid "button_write_and_import"
@@ -171,6 +176,11 @@ msgstr ""
 msgid "description_update_security"
 msgstr ""
 
+#. Default: "Update specifications and create an upgrade step with ftw.upgrade."
+#: ./ftw/lawgiver/browser/templates/speclisting.pt:66
+msgid "description_update_specs_with_upgradestep"
+msgstr ""
+
 #. Default: "When the \"${button_title}\" button is clicked the workflow is generated and written to the <i title=\"${DYNAMIC_CONTENT}\">definition.xml</i> and then the workflow is imported using Generic Setup."
 #: ./ftw/lawgiver/browser/templates/details.pt:121
 msgid "description_write_and_import"
@@ -187,12 +197,12 @@ msgstr ""
 
 #. Default: "${id}: The specification file could not be parsed: ${error}"
 #: ./ftw/lawgiver/browser/details.py:187
-#: ./ftw/lawgiver/updater.py:133
+#: ./ftw/lawgiver/updater.py:197
 msgid "error_parsing_error"
 msgstr ""
 
 #. Default: "${id}: Error while generating the workflow: ${msg}"
-#: ./ftw/lawgiver/updater.py:81
+#: ./ftw/lawgiver/updater.py:145
 msgid "error_while_generating_workflow"
 msgstr ""
 
@@ -201,7 +211,7 @@ msgid "ftw.lawgiver"
 msgstr ""
 
 #. Default: "${id}: The translations were updated in your locales directory. You should now run bin/i18n-build"
-#: ./ftw/lawgiver/updater.py:112
+#: ./ftw/lawgiver/updater.py:176
 msgid "info_locales_updated"
 msgstr ""
 
@@ -211,7 +221,7 @@ msgid "info_security_updated"
 msgstr ""
 
 #. Default: "${id}: The workflow was generated to ${path}."
-#: ./ftw/lawgiver/updater.py:94
+#: ./ftw/lawgiver/updater.py:158
 msgid "info_workflow_generated"
 msgstr ""
 
@@ -260,7 +270,7 @@ msgid "view inactive objects"
 msgstr ""
 
 #. Default: "${id}: Skipping released specification."
-#: ./ftw/lawgiver/updater.py:51
+#: ./ftw/lawgiver/updater.py:69
 msgid "warning_skipped_released_spec"
 msgstr ""
 

--- a/ftw/lawgiver/testing.py
+++ b/ftw/lawgiver/testing.py
@@ -2,13 +2,15 @@ from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
 from ftw.testing import ComponentRegistryLayer
-from plone.app.testing import IntegrationTesting
+from ftw.testing.layer import TEMP_DIRECTORY
+from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
+from plone.app.testing import IntegrationTesting
 from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import applyProfile
 from plone.testing import z2
 from zope.configuration import xmlconfig
+import ftw.lawgiver.tests.builders
 
 
 class MetaZCMLLayer(ComponentRegistryLayer):
@@ -37,7 +39,7 @@ ZCML_FIXTURE = ZCMLLayer()
 
 class LawgiverLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER, TEMP_DIRECTORY)
 
     def setUpZope(self, app, configurationContext):
         # The first definition of an action group defines the the

--- a/ftw/lawgiver/testing.py
+++ b/ftw/lawgiver/testing.py
@@ -2,11 +2,11 @@ from ftw.builder.testing import BUILDER_LAYER
 from ftw.builder.testing import functional_session_factory
 from ftw.builder.testing import set_builder_session_factory
 from ftw.testing import ComponentRegistryLayer
+from ftw.testing.layer import COMPONENT_REGISTRY_ISOLATION
 from ftw.testing.layer import TEMP_DIRECTORY
 from plone.app.testing import applyProfile
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from plone.testing import z2
 from zope.configuration import xmlconfig
@@ -39,7 +39,7 @@ ZCML_FIXTURE = ZCMLLayer()
 
 class LawgiverLayer(PloneSandboxLayer):
 
-    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER, TEMP_DIRECTORY)
+    defaultBases = (COMPONENT_REGISTRY_ISOLATION, BUILDER_LAYER, TEMP_DIRECTORY)
 
     def setUpZope(self, app, configurationContext):
         # The first definition of an action group defines the the

--- a/ftw/lawgiver/tests/builders.py
+++ b/ftw/lawgiver/tests/builders.py
@@ -1,7 +1,8 @@
 from ftw.builder import Builder
-from ftw.lawgiver.tests.helpers import EXAMPLE_WF_SPEC
-from ftw.lawgiver.tests.helpers import EXAMPLE_WF_DEF
 from ftw.builder import builder_registry
+from ftw.lawgiver.tests.helpers import EXAMPLE_WF_DEF
+from ftw.lawgiver.tests.helpers import EXAMPLE_WF_SPEC
+from ftw.lawgiver.tests.helpers import EXAMPLE_WORKFLOW_DIR
 
 
 class PackageWithWorkflowBuilder(object):
@@ -10,18 +11,23 @@ class PackageWithWorkflowBuilder(object):
         self.session = session
         self.profile_builder = (
             Builder('genericsetup profile')
-            .with_file('workflows/my_custom_workflow/specification.txt',
-                       EXAMPLE_WF_SPEC.bytes(),
-                       makedirs=True)
-            .with_file('workflows/my_custom_workflow/definition.xml',
-                       EXAMPLE_WF_DEF.bytes(),
-                       makedirs=True))
+            .with_file(
+                'workflows/{}/specification.txt'.format(
+                    EXAMPLE_WORKFLOW_DIR.name),
+                EXAMPLE_WF_SPEC.bytes(),
+                makedirs=True)
+            .with_file(
+                'workflows/{}/definition.xml'.format(
+                    EXAMPLE_WORKFLOW_DIR.name),
+                EXAMPLE_WF_DEF.bytes(),
+                makedirs=True))
 
         self.package_builder = (
             Builder('python package')
             .named('the.package')
             .with_profile(self.profile_builder)
-            .with_directory('locales/de/LC_MESSAGES'))
+            .with_directory('locales/de/LC_MESSAGES')
+            .with_directory('upgrades'))
 
     def with_layer(self, layer):
         self.package_builder.at_path(layer['temp_directory'])

--- a/ftw/lawgiver/tests/builders.py
+++ b/ftw/lawgiver/tests/builders.py
@@ -1,0 +1,34 @@
+from ftw.builder import Builder
+from ftw.lawgiver.tests.helpers import EXAMPLE_WF_SPEC
+from ftw.lawgiver.tests.helpers import EXAMPLE_WF_DEF
+from ftw.builder import builder_registry
+
+
+class PackageWithWorkflowBuilder(object):
+
+    def __init__(self, session):
+        self.session = session
+        self.profile_builder = (
+            Builder('genericsetup profile')
+            .with_file('workflows/my_custom_workflow/specification.txt',
+                       EXAMPLE_WF_SPEC.bytes(),
+                       makedirs=True)
+            .with_file('workflows/my_custom_workflow/definition.xml',
+                       EXAMPLE_WF_DEF.bytes(),
+                       makedirs=True))
+
+        self.package_builder = (
+            Builder('python package')
+            .named('the.package')
+            .with_profile(self.profile_builder)
+            .with_directory('locales/de/LC_MESSAGES'))
+
+    def with_layer(self, layer):
+        self.package_builder.at_path(layer['temp_directory'])
+        return self
+
+    def create(self, **kwargs):
+        return self.package_builder.create(**kwargs)
+
+
+builder_registry.register('package with workflow', PackageWithWorkflowBuilder)

--- a/ftw/lawgiver/tests/helpers.py
+++ b/ftw/lawgiver/tests/helpers.py
@@ -1,6 +1,8 @@
 from path import Path
 from Products.CMFPlone.utils import getFSVersionTuple
 import os
+import shlex
+import subprocess
 
 
 ASSETS = Path(__file__).joinpath('..', 'assets').abspath()
@@ -37,3 +39,15 @@ def cleanup_path(path, snapshot_before):
             os.unlink(path)
         if os.path.isdir(path):
             os.removedirs(path)
+
+
+def run_command(cmd, cwd=None):
+    proc = subprocess.Popen(shlex.split(cmd),
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.STDOUT,
+                            cwd=cwd)
+
+    stdout, stderr = proc.communicate()
+    if proc.poll():
+        raise Exception('Error while running "{0}":\n{1}'.format(
+            cmd, stdout + stderr))

--- a/ftw/lawgiver/tests/helpers.py
+++ b/ftw/lawgiver/tests/helpers.py
@@ -1,4 +1,22 @@
+from path import Path
+from Products.CMFPlone.utils import getFSVersionTuple
 import os
+
+
+ASSETS = Path(__file__).joinpath('..', 'assets').abspath()
+PLONE_VERSION = getFSVersionTuple()
+
+
+if PLONE_VERSION >= (4, 3, 5):
+    EXAMPLE_WORKFLOW_DIR = ASSETS.joinpath('example-4.3.5')
+elif PLONE_VERSION > (4, 3):
+    EXAMPLE_WORKFLOW_DIR = ASSETS.joinpath('example-4.3.4')
+else:
+    EXAMPLE_WORKFLOW_DIR = ASSETS.joinpath('example-4.2')
+
+
+EXAMPLE_WF_SPEC = EXAMPLE_WORKFLOW_DIR.joinpath('specification.txt')
+EXAMPLE_WF_DEF = EXAMPLE_WORKFLOW_DIR.joinpath('definition.xml')
 
 
 def filestructure_snapshot(path):

--- a/ftw/lawgiver/tests/test_updater.py
+++ b/ftw/lawgiver/tests/test_updater.py
@@ -1,9 +1,13 @@
+from datetime import datetime
 from ftw.builder import Builder
 from ftw.builder import create
 from ftw.lawgiver.interfaces import IUpdater
 from ftw.lawgiver.testing import LAWGIVER_FUNCTIONAL_TESTING
 from ftw.lawgiver.testing import SPECIFICATIONS_FUNCTIONAL
 from ftw.lawgiver.tests.base import XMLDiffTestCase
+from ftw.lawgiver.tests.helpers import EXAMPLE_WORKFLOW_DIR
+from ftw.lawgiver.tests.helpers import run_command
+from ftw.testing import freeze
 from path import Path
 from unittest2 import TestCase
 from zope.component import getUtility
@@ -51,7 +55,7 @@ class TestUpdateSpecifications(XMLDiffTestCase):
 
         package = create(Builder('package with workflow').with_layer(self.layer))
         workflow_dir = package.package_path.joinpath(
-            'profiles', 'default', 'workflows', 'my_custom_workflow')
+            'profiles', 'default', 'workflows', EXAMPLE_WORKFLOW_DIR.name)
         wf_definition = workflow_dir.joinpath('definition.xml')
         wf_spec = workflow_dir.joinpath('specification.txt')
 
@@ -68,3 +72,41 @@ class TestUpdateSpecifications(XMLDiffTestCase):
                              wf_definition.bytes())
             self.assertIn('Another three state publication workflow',
                           wf_definition.bytes())
+
+    def test_update_all_specifications_with_upgrade_step(self):
+        self.maxDiff = None
+
+        package = create(Builder('package with workflow').with_layer(self.layer))
+        workflow_dir = package.package_path.joinpath(
+            'profiles', 'default', 'workflows', EXAMPLE_WORKFLOW_DIR.name)
+        wf_definition = workflow_dir.joinpath('definition.xml')
+        wf_spec = workflow_dir.joinpath('specification.txt')
+
+        run_command('git init .', package.package_path)
+        run_command('git add .', package.package_path)
+        run_command('git commit --no-gpg-sign -m "init"', package.package_path)
+
+        with package.zcml_loaded(self.layer['configurationContext']):
+            wf_spec.write_bytes(wf_spec.bytes().replace(
+                'Description: A three state publication workflow',
+                'Description: Another three state publication workflow'))
+
+            with freeze(datetime(2010, 1, 1)):
+                getUtility(IUpdater).update_all_specifications_with_upgrade_step()
+
+            upgrade_dir = package.package_path.joinpath(
+                'upgrades', '20100101000000_update_workflows')
+            self.assertTrue(upgrade_dir.isdir(), upgrade_dir)
+
+            wf_definition = upgrade_dir.joinpath(
+                'workflows', EXAMPLE_WORKFLOW_DIR.name, 'definition.xml')
+            self.assertTrue(wf_definition.isfile(), wf_definition)
+
+            upgrade_code = upgrade_dir.joinpath('upgrade.py').bytes()
+
+            self.assertIn(
+                '\n        self.update_workflow_security(\n'
+                '            [\'{}\'],\n'
+                '            reindex_security=False)'.format(
+                    EXAMPLE_WORKFLOW_DIR.name),
+                upgrade_code)

--- a/ftw/lawgiver/updater.py
+++ b/ftw/lawgiver/updater.py
@@ -1,10 +1,15 @@
+from collections import defaultdict
 from ftw.lawgiver import _
+from ftw.lawgiver.exceptions import UpgradeStepCreationError
 from ftw.lawgiver.i18nbuilder import I18nBuilder
 from ftw.lawgiver.interfaces import IUpdater
 from ftw.lawgiver.interfaces import IWorkflowGenerator
 from ftw.lawgiver.interfaces import IWorkflowSpecificationDiscovery
 from ftw.lawgiver.utils import in_development
 from ftw.lawgiver.wdl.interfaces import IWorkflowSpecificationParser
+from lxml import etree
+from operator import attrgetter
+from path import Path
 from Products.statusmessages.interfaces import IStatusMessage
 from ZODB.POSException import ConflictError
 from zope.component import getMultiAdapter
@@ -13,7 +18,19 @@ from zope.component.hooks import getSite
 from zope.i18n import translate
 from zope.interface import implements
 import os.path
+import pkg_resources
+import shlex
+import subprocess
 import sys
+
+
+try:
+    pkg_resources.get_distribution('ftw.upgrade')
+except pkg_resources.DistributionNotFound:
+    FTW_UPGRADE_INSTALLED = False
+else:
+    FTW_UPGRADE_INSTALLED = True
+    from ftw.upgrade.directory.scaffold import UpgradeStepCreator
 
 
 class StatusMessageFormatter(object):
@@ -43,6 +60,7 @@ class Updater(object):
     def update_all_specifications(self, output_formatter=None):
         discovery = getMultiAdapter((getSite(), getSite().REQUEST),
                                     IWorkflowSpecificationDiscovery)
+        result = []
         for specification_path in discovery.discover():
             if not in_development(specification_path):
                 if output_formatter:
@@ -51,17 +69,65 @@ class Updater(object):
                         _(u'warning_skipped_released_spec',
                           default=u'${id}: Skipping released specification.',
                           mapping={
-                                'id': self._workflow_id(specification_path)}))
+                              'id': self._workflow_id(specification_path)}))
                 continue
 
             self.write_workflow(specification_path,
                                 output_formatter=output_formatter)
             self.update_translations(specification_path,
                                      output_formatter=output_formatter)
+            result.append(specification_path)
+
+        return result
+
+    def update_all_specifications_with_upgrade_step(
+            self, output_formatter=None):
+        if not FTW_UPGRADE_INSTALLED:
+            raise UpgradeStepCreationError('ftw.upgrade is not installed.')
+
+        by_packages = defaultdict(list)
+        for specification_path in self.update_all_specifications(
+                output_formatter=output_formatter):
+            pkg_path = (Path(specification_path)
+                        .joinpath('..', '..', '..', '..', '..')
+                        .abspath())
+            by_packages[pkg_path].append(Path(specification_path))
+
+        for pkg_path, spec_paths in by_packages.items():
+            upgrades_path = pkg_path.joinpath('upgrades')
+            if not upgrades_path.isdir():
+                raise UpgradeStepCreationError('Missing folder at {!r}'.format(
+                    upgrades_path))
+
+            wf_names_by_reindex_flag = {False: [], True: []}
+            upgrade_dir = (UpgradeStepCreator(upgrades_path)
+                           .create('Update workflows.'))
+            for spec_path in spec_paths:
+                def_path = spec_path.joinpath('..', 'definition.xml').abspath()
+                wf_name = spec_path.parent.name
+                target_dir = upgrade_dir.joinpath('workflows', wf_name)
+                target_dir.makedirs()
+                def_path.copy(target_dir.joinpath('definition.xml'))
+                wf_names_by_reindex_flag[
+                    self._has_view_permission_changed(def_path)].append(
+                        str(wf_name))
+
+            upgrade_module = upgrade_dir.joinpath('upgrade.py')
+            for flag, wf_names in wf_names_by_reindex_flag.items():
+                if not wf_names:
+                    continue
+
+                upgrade_module.write_bytes(
+                    upgrade_module.bytes() +
+                    '        self.update_workflow_security(\n'
+                    '            [\'{}\'],\n'
+                    '            reindex_security={!r})\n'
+                    .format(('\',\n             \'').join(wf_names),
+                            flag))
 
     def write_workflow(self, specification_path, output_formatter=None):
-        specification = self._get_specification(specification_path,
-                                                output_formatter=output_formatter)
+        specification = self._get_specification(
+            specification_path, output_formatter=output_formatter)
         if not specification:
             return False
 
@@ -98,8 +164,8 @@ class Updater(object):
         return True
 
     def update_translations(self, specification_path, output_formatter=None):
-        specification = self._get_specification(specification_path,
-                                                output_formatter=output_formatter)
+        specification = self._get_specification(
+            specification_path, output_formatter=output_formatter)
         if not specification:
             return False
 
@@ -143,3 +209,35 @@ class Updater(object):
     def _definition_path(self, specification_path):
         return os.path.join(os.path.dirname(specification_path),
                             'definition.xml')
+
+    def _has_view_permission_changed(self, definition_path):
+        command = 'git show HEAD:./{0}'.format(definition_path.name)
+        proc = subprocess.Popen(
+            shlex.split(command),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=definition_path.parent)
+
+        stdout, stderr = proc.communicate()
+        if proc.poll():
+            raise UpgradeStepCreationError(
+                'Error while running {0!r}.\n{1}\n{2}'.format(
+                    command, stdout, stderr))
+
+        old_definition_xml = stdout
+        new_definition_xml = definition_path.bytes()
+
+        old_roles = self.get_view_permission_roles(old_definition_xml)
+        new_roles = self.get_view_permission_roles(new_definition_xml)
+        return old_roles != new_roles
+
+    def get_view_permission_roles(self, workflow_definition):
+        doc = etree.fromstring(workflow_definition)
+        result = {}
+        for state_tag in doc.xpath('//state'):
+            result[state_tag.attrib['state_id']] = map(
+                attrgetter('text'),
+                state_tag.xpath(
+                    'permission-map[@name="View"]/permission-role'))
+
+        return result


### PR DESCRIPTION
In the lawgiver control panel is a button for rebuilding all lawgiver workflows and updating their translations.
This PR adds a new button which does the same but also creates an upgrade step installing the workflow changes.
The upgrade step does only work when there is an `upgrade` package configured as `ftw.upgrade` upgrade step directory.
The upgrade step assumes that all workflows were already installed and updates them.
When the `View` permission was changed, the security indexes are reindexed for the affected objects.

![bildschirmfoto 2017-01-03 um 09 27 12](https://cloud.githubusercontent.com/assets/7469/21602665/dbf00308-d196-11e6-8f19-d5dfbc7b103e.png)

<img width="1089" alt="bildschirmfoto 2017-01-03 um 09 28 25" src="https://cloud.githubusercontent.com/assets/7469/21602681/003a4782-d197-11e6-8197-fd754ef98e67.png">

```python
from ftw.upgrade import UpgradeStep


class UpdateWorkflows(UpgradeStep):
    """Update workflows.
    """

    def __call__(self):
        self.install_upgrade_profile()
        self.update_workflow_security(
            ['workspace-content',
             'workspace',
             'templates',
             'workspaces-folder',
             'undeletable'],
            reindex_security=False)
```