### PR TITLE
Fix typos in german translation files

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix typos in German translation [raphael-s]
 
 
 1.9.0 (2017-01-03)

--- a/ftw/lawgiver/locales/de/LC_MESSAGES/ftw.lawgiver.po
+++ b/ftw/lawgiver/locales/de/LC_MESSAGES/ftw.lawgiver.po
@@ -21,7 +21,7 @@ msgstr "Standard Übersetzungen"
 
 #: ./ftw/lawgiver/profiles.zcml:13
 msgid "Generate workflows from human readable specifications."
-msgstr "Workflows aus von menschen lesbaren Spezifikationen generieren"
+msgstr "Workflows aus von Menschen lesbaren Spezifikationen generieren."
 
 #: ./ftw/lawgiver/browser/templates/import-confirmation.pt:51
 msgid "I am on production"
@@ -156,12 +156,12 @@ msgstr "löschen"
 #. Default: "This view lists all workflow specifications. Workflow specifications are identified by the \"specification.txt\" in the corresponding workflow directory of any generic setup profile."
 #: ./ftw/lawgiver/browser/templates/speclisting.pt:26
 msgid "description_manage_upgrades"
-msgstr "Diese Ansicht zeigt alle Workflow-Spezifikationen an. Workflow-Spezifikationen werden anhand des der Datei \"specification.txt\" im entsprechenden Workflow-Verzeichnis des Generic-Setup Profils erkannt."
+msgstr "Diese Ansicht zeigt alle Workflow-Spezifikationen an. Workflow-Spezifikationen werden anhand der Datei \"specification.txt\" im entsprechenden Workflow-Verzeichnis des Generic-Setup Profils erkannt."
 
 #. Default: "This rebuilds all specifications and saves the workflows to the definition.xml. It also updates the translations for each specification. Specifications which are suspected to be in a released egg are skipped."
 #: ./ftw/lawgiver/browser/templates/speclisting.pt:53
 msgid "description_update_all_specs"
-msgstr "Aktualisiert alle Worfklows (definition.xml) der aufgelisteten Workflows und aktualisiert die Übersetzungsdateien. Spezifikationen, welche sich in einem \".egg\" befinden werden ignoriert."
+msgstr "Aktualisiert alle aufgelisteten Workflows (definition.xml) und aktualisiert die Übersetzungsdateien. Spezifikationen, welche sich in einem \".egg\" befinden werden ignoriert."
 
 #. Default: "Updates the ${pot-name} and the ${po-name} files in your locales directory (${locales_directory})."
 #: ./ftw/lawgiver/browser/templates/details.pt:147
@@ -171,22 +171,22 @@ msgstr "Aktualisiert Übersetzungs-Dateien ${pot-name} und ${po-name} in dem loc
 #. Default: "When the \"${button_title}\" button is clicked the security of all (!) objects in your database are updated. This is the same button as in portal_workflow."
 #: ./ftw/lawgiver/browser/templates/details.pt:131
 msgid "description_update_security"
-msgstr "Der Button \"${button_title}\" aktualisiert die Sicherheitseinstellungen aller (!) objekte auf dieser Plone-Seite. Dies ist der gleiche Button wie der \"Update security settings\" in portal_workflow."
+msgstr "Der Button \"${button_title}\" aktualisiert die Sicherheitseinstellungen aller (!) Objekte auf dieser Plone-Seite. Dies ist der gleiche Button wie der \"Update security settings\" in portal_workflow."
 
 #. Default: "Update specifications and create an upgrade step with ftw.upgrade."
 #: ./ftw/lawgiver/browser/templates/speclisting.pt:66
 msgid "description_update_specs_with_upgradestep"
-msgstr "Spezifikationen aktualiseren und einen Upgrade Step erstellen. Dies benötigt ein registriertes ftw.upgrade upgrade-step:directory mit dem Name \"upgrades\"."
+msgstr "Spezifikationen aktualisieren und einen Upgrade Step erstellen. Dies benötigt ein registriertes ftw.upgrade upgrade-step:directory mit dem Name \"upgrades\"."
 
 #. Default: "When the \"${button_title}\" button is clicked the workflow is generated and written to the <i title=\"${DYNAMIC_CONTENT}\">definition.xml</i> and then the workflow is imported using Generic Setup."
 #: ./ftw/lawgiver/browser/templates/details.pt:121
 msgid "description_write_and_import"
-msgstr "Der Button \"${button_title}\" generiert den Workflow neu und schreibt ih in die Datei <i title=\\\"${DYNAMIC_CONTENT}\\\">definition.xml</i>. Anschliessend wird der Workflow mittels Generic Setup in dieser Plone-Seite installiert."
+msgstr "Der Button \"${button_title}\" generiert den Workflow neu und schreibt ihn in die Datei <i title=\\\"${DYNAMIC_CONTENT}\\\">definition.xml</i>. Anschliessend wird der Workflow mittels Generic Setup in dieser Plone-Seite installiert."
 
 #. Default: "When the \"${button_title}\" button is clicked the workflow is generated and written to the <i title=\"${DYNAMIC_CONTENT}\">definition.xml</i>. The database / portal_workflow is not changed."
 #: ./ftw/lawgiver/browser/templates/details.pt:91
 msgid "description_write_wf_definition"
-msgstr "Der Button \"${button_title}\" generiert den Workflow neu und schreibt ih in die Datei <i title=\\\"${DYNAMIC_CONTENT}\\\">definition.xml</i>. Die Datenbank wird nicht verändert."
+msgstr "Der Button \"${button_title}\" generiert den Workflow neu und schreibt ihn in die Datei <i title=\\\"${DYNAMIC_CONTENT}\\\">definition.xml</i>. Die Datenbank wird nicht verändert."
 
 #: ./ftw/lawgiver/lawgiver.zcml
 msgid "edit"
@@ -210,7 +210,7 @@ msgstr "ftw.lawgiver"
 #. Default: "${id}: The translations were updated in your locales directory. You should now run bin/i18n-build"
 #: ./ftw/lawgiver/updater.py:176
 msgid "info_locales_updated"
-msgstr "${id}: Die Übersetzungen wurden im locales-Verzeichnis aktualisert. Jetzt sollt bin/i18n-build ausgeführt werden."
+msgstr "${id}: Die Übersetzungen wurden im locales-Verzeichnis aktualisiert. Jetzt sollte bin/i18n-build ausgeführt werden."
 
 #. Default: "Security update: ${amount} objects updated."
 #: ./ftw/lawgiver/browser/details.py:139
@@ -274,4 +274,4 @@ msgstr "${id}: Package bereits released, Workflow wurde nicht aktualisiert."
 #. Default: "The workflow ${workflow} is not installed yet. Installing the workflow with the \"${button_title}\" button does not configure the policy, so no portal type will have this workflow."
 #: ./ftw/lawgiver/browser/templates/details.pt:103
 msgid "warning_workflow_not_installed"
-msgstr "Der Workflow ${workflow} ist noch nicht installiert. Wenn der Workflow mit dem Button \"${button_title}\" installiert wird die Workflow Policy nicht angepasst, d.H. kein Typ wird diesen Workflow automatisch benutzen."
+msgstr "Der Workflow ${workflow} ist noch nicht installiert. Wenn der Workflow mit dem Button \"${button_title}\" installiert wird, wird die Workflow Policy nicht angepasst. D.h. kein Typ wird diesen Workflow automatisch benutzen."


### PR DESCRIPTION
I noticed a small typo when using `ftw.lawgiver`, so i quickly reviewed all the german translations and found even more typos 😄 

I think I fixed most of them now.