### PR TITLE
Fix review state translation in sharing page role description popup.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,8 @@ Changelog
 1.10.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix review state translation in sharing page role description popup.
+  The review state is now translated by the state title, not the id. [jone]
 
 1.10.0 (2017-07-11)
 -------------------

--- a/ftw/lawgiver/browser/sharing.py
+++ b/ftw/lawgiver/browser/sharing.py
@@ -72,8 +72,14 @@ class SharingDescribeRole(BrowserView):
         generator = getUtility(IWorkflowGenerator)
         generator.workflow_id = workflow.id
         for status in spec.states.values():
-            headers.append(self._translate(generator._status_id(status),
-                                           default=status.title))
+            # ftw.lawgiver<1.6.1 used to translate the review state ID.
+            # For backwards compatibility use that as fallback.
+            old_translation = self._translate(generator._status_id(status),
+                                              default=status.title)
+            # Plone translates the review state title.
+            correct_translation = self._translate(status.title,
+                                                  default=old_translation)
+            headers.append(correct_translation)
         return headers
 
     def _generate_table_rows(self, spec, rolename):

--- a/ftw/lawgiver/tests/locales/de/LC_MESSAGES/ftw.lawgiver.po
+++ b/ftw/lawgiver/tests/locales/de/LC_MESSAGES/ftw.lawgiver.po
@@ -1,0 +1,31 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2013-04-22 08:12+0000\n"
+"PO-Revision-Date: 2017-07-25 19:33+0200\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#. Default: "Pending"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Pending"
+msgstr "Eingereicht"
+
+#. Default: "Private"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Private"
+msgstr "Privat"
+
+#. Default: "Published"
+#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Published"
+msgstr "Publiziert"

--- a/ftw/lawgiver/tests/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/lawgiver/tests/locales/de/LC_MESSAGES/plone.po
@@ -2,19 +2,22 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "POT-Creation-Date: 2013-04-22 08:12+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"PO-Revision-Date: 2017-07-25 19:33+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
 "Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
 
 #. Default: "Published"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
 msgid "Published"
-msgstr "Publiziert"
+msgstr "Veröffentlicht"
 
 msgid "local-roles--ROLE--Editor"
 msgstr ""
@@ -22,54 +25,48 @@ msgstr ""
 msgid "local-roles--ROLE--Reviewer"
 msgstr ""
 
+#. Default: "everyone"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "my_custom_workflow--ROLE--Anonymous"
 msgstr "Alle"
 
+#. Default: "editor"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "my_custom_workflow--ROLE--Editor"
 msgstr "Redaktor"
 
+#. Default: "system administrator"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "my_custom_workflow--ROLE--Manager"
 msgstr "System Administrator"
 
+#. Default: "editor-in-chief"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "my_custom_workflow--ROLE--Reviewer"
 msgstr "Chefredaktor"
 
+#. Default: "administrator"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "my_custom_workflow--ROLE--Site Administrator"
 msgstr "Administrator"
 
-msgid "my_custom_workflow--STATUS--pending"
-msgstr "Eingereicht"
+#. Default: "The editor-in-chief reviews and publishes content."
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "my_custom_workflow--ROLE-DESCRIPTION--Reviewer"
+msgstr ""
 
-msgid "my_custom_workflow--STATUS--private"
-msgstr "Privat"
-
-msgid "my_custom_workflow--STATUS--published"
-msgstr "Publiziert"
-
-msgid "my_custom_workflow--TRANSITION--publish--pending_published"
-msgstr "Publizieren"
-
-msgid "my_custom_workflow--TRANSITION--publish--private_published"
-msgstr "Publizieren"
-
-msgid "my_custom_workflow--TRANSITION--reject--pending_private"
-msgstr "Zurückweisen"
-
-msgid "my_custom_workflow--TRANSITION--retract--pending_private"
-msgstr "Zurückziehen"
-
-msgid "my_custom_workflow--TRANSITION--retract--published_private"
-msgstr "Zurückzeiehn"
-
-msgid "my_custom_workflow--TRANSITION--submit-for-publication--private_pending"
-msgstr "Zur Publikation einreichen"
-
+#. Default: "publish"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "publish"
 msgstr "Publizieren"
 
+#. Default: "reject"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "reject"
 msgstr "Zurückweisen"
 
+#. Default: "retract"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "retract"
 msgstr "Zurückziehen"
 
@@ -79,6 +76,8 @@ msgstr "editor"
 msgid "role-translation--ROLE--Reviewer"
 msgstr "editor-in-chief"
 
+#. Default: "submit for publication"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "submit for publication"
 msgstr "Zur Publikation einreichen"
 

--- a/ftw/lawgiver/tests/locales/en/LC_MESSAGES/ftw.lawgiver.po
+++ b/ftw/lawgiver/tests/locales/en/LC_MESSAGES/ftw.lawgiver.po
@@ -1,0 +1,31 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2013-04-22 08:12+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Language-Code: en\n"
+"Language-Name: English\n"
+"Preferred-Encodings: utf-8 latin1\n"
+"Domain: DOMAIN\n"
+
+#. Default: "Pending"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Pending"
+msgstr "Pending"
+
+#. Default: "Private"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Private"
+msgstr "Private"
+
+#. Default: "Published"
+#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Published"
+msgstr "Published"

--- a/ftw/lawgiver/tests/locales/en/LC_MESSAGES/plone.po
+++ b/ftw/lawgiver/tests/locales/en/LC_MESSAGES/plone.po
@@ -11,19 +11,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
-#. Default: "Pending"
-#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
-msgid "Pending"
-msgstr "Pending"
-
-#. Default: "Private"
-#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
-msgid "Private"
-msgstr "Private"
-
 #. Default: "Published"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "Published"
 msgstr "Published"
 

--- a/ftw/lawgiver/tests/locales/ftw.lawgiver.pot
+++ b/ftw/lawgiver/tests/locales/ftw.lawgiver.pot
@@ -1,0 +1,32 @@
+# --- PLEASE EDIT THE LINES BELOW CORRECTLY ---
+# SOME DESCRIPTIVE TITLE.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: 2013-04-22 08:12+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0\n"
+"Preferred-Encodings: utf-8 latin1\n"
+
+#. Default: "Pending"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Pending"
+msgstr ""
+
+#. Default: "Private"
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Private"
+msgstr ""
+
+#. Default: "Published"
+#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
+#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
+msgid "Published"
+msgstr ""
+

--- a/ftw/lawgiver/tests/locales/i18n-sync.sh
+++ b/ftw/lawgiver/tests/locales/i18n-sync.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+set -eu -o pipefail
+
+for potfile in *.pot; do
+  domain=${potfile%.*}
+  pofiles=$(find . -name "$domain.po")
+  ../../../../bin/i18ndude sync -p $potfile $pofiles
+done

--- a/ftw/lawgiver/tests/locales/plone.pot
+++ b/ftw/lawgiver/tests/locales/plone.pot
@@ -14,19 +14,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
-#. Default: "Pending"
-#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
-msgid "Pending"
-msgstr ""
-
-#. Default: "Private"
-#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
-msgid "Private"
-msgstr ""
-
 #. Default: "Published"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-#: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "Published"
 msgstr ""
 


### PR DESCRIPTION
With ``ftw.lawgiver==1.6.1`` the translation of the review state was [changed from translating the state id to translating the state title](https://github.com/4teamwork/ftw.lawgiver/pull/60). This has changed because Plone also uses the review state title.

The role description popup of the sharing page was not updated in that change and thus did not correctly translate the review state title in the table heading.

This change changes the translation behavior of the state in the popup so that we try to translate it the correct way (using the state title) and gracefully fallback to the old behavior by using it as translation default.

![bildschirmfoto 2017-07-26 um 08 46 14](https://user-images.githubusercontent.com/7469/28608053-108450b8-71df-11e7-9db9-d120d89bcae2.png)
![bildschirmfoto 2017-07-26 um 08 46 33](https://user-images.githubusercontent.com/7469/28608055-12ecdf8c-71df-11e7-8fd9-eb4e6f499e36.png)

```
opengever/core/locales/de/LC_MESSAGES/plone.po:#. Default: "Active"
opengever/core/locales/de/LC_MESSAGES/plone.po-#: opengever/core/profiles/default/workflows/opengever_committee_workflow/specification.txt
opengever/core/locales/de/LC_MESSAGES/plone.po-#: opengever/core/profiles/default/workflows/opengever_committeecontainer_workflow/specification.txt
opengever/core/locales/de/LC_MESSAGES/plone.po:msgid "Active"
opengever/core/locales/de/LC_MESSAGES/plone.po-msgstr "Aktiv"
```

**Implementation details:**
The role description is tested with an example 3-state workflow.
Since we use quite common states such as "Private" or "Pending", those terms are already translated by Plone in the `plone` differently.
Since the `self._translate` method always first translates in the `ftw.lawgiver` domain, then in the `plone` domain, I could simply move the relevant translations from `plone` to `ftw.lawgiver`. I couldn't override existing translations in the `plone` domain easily because of testing setup reasons.
I added a little shell script for syncing the testing translations for convenience.