### PR TITLE
Control panel: separate unmapped permissions into ignored and unknown groups.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.10.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Control panel: separate unmapped permissions into ignored and unknown groups. [jone]
 
 1.10.1 (2017-07-27)
 -------------------

--- a/ftw/lawgiver/browser/details.py
+++ b/ftw/lawgiver/browser/details.py
@@ -1,5 +1,6 @@
 from ftw.lawgiver import _
 from ftw.lawgiver.i18nbuilder import I18nBuilder
+from ftw.lawgiver.interfaces import IActionGroupRegistry
 from ftw.lawgiver.interfaces import IPermissionCollector
 from ftw.lawgiver.interfaces import IUpdater
 from ftw.lawgiver.interfaces import IWorkflowGenerator
@@ -234,8 +235,13 @@ class SpecDetails(BrowserView):
         unmanaged = managed['unmanaged']
         del managed['unmanaged']
 
+        ignored = sorted(getUtility(IActionGroupRegistry).get_ignored_permissions(
+            workflow_name=workflow_name))
+        unknown = sorted(list(set(unmanaged) - set(ignored)))
+
         return {'managed': managed,
-                'unmanaged': unmanaged}
+                'ignored': ignored,
+                'unknown': unknown}
 
     def pot_data(self):
         return self._get_translations(fill_default=False)

--- a/ftw/lawgiver/browser/templates/details.pt
+++ b/ftw/lawgiver/browser/templates/details.pt
@@ -199,10 +199,20 @@
                     Unmanaged permissions
                 </dt>
                 <dd class="collapsibleContent">
+                  <div class="ignored-permissions">
+                    <b i18n:translate="">Ignored permissions</b>
                     <ul>
-                        <li tal:repeat="perm permissions/unmanaged"
+                        <li tal:repeat="perm permissions/ignored"
                             tal:content="perm" />
                     </ul>
+                  </div>
+                  <div class="unkown-permissions">
+                    <b i18n:translate="">Unknown permissions (neither ignored nor mapped)</b>
+                    <ul>
+                        <li tal:repeat="perm permissions/unknown"
+                            tal:content="perm" />
+                    </ul>
+                  </div>
                 </dd>
 
             </dl>

--- a/ftw/lawgiver/locales/de/LC_MESSAGES/ftw.lawgiver.po
+++ b/ftw/lawgiver/locales/de/LC_MESSAGES/ftw.lawgiver.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-01-01 11:45+0000\n"
+"POT-Creation-Date: 2017-12-03 08:46+0000\n"
 "PO-Revision-Date: 2014-09-08 12:16+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Could not find any information about this role."
 msgstr "Es sind nicht genügend Informationen über diese Rolle vorhanden."
 
-#: ./ftw/lawgiver/browser/templates/details.pt:221
+#: ./ftw/lawgiver/browser/templates/details.pt:231
 msgid "Default translations"
 msgstr "Standard Übersetzungen"
 
@@ -30,6 +30,10 @@ msgstr "Das ist ein Produktivsystem"
 #: ./ftw/lawgiver/browser/templates/import-confirmation.pt:45
 msgid "I know what I am doing"
 msgstr "Ich weiss was ich mache"
+
+#: ./ftw/lawgiver/browser/templates/details.pt:203
+msgid "Ignored permissions"
+msgstr "Ignorierte Berechtigungen"
 
 #: ./ftw/lawgiver/browser/templates/import-confirmation.pt:26
 msgid "Importing this workflow renames or removes states. Changing states can reset the workflow status of affected objects to the initial state."
@@ -63,7 +67,7 @@ msgstr "Spezifikation Details"
 msgid "Specification file:"
 msgstr "Workflow Spezifikation:"
 
-#: ./ftw/lawgiver/browser/templates/details.pt:217
+#: ./ftw/lawgiver/browser/templates/details.pt:227
 msgid "Template"
 msgstr "Vorlage"
 
@@ -71,7 +75,7 @@ msgstr "Vorlage"
 msgid "The workflow seems to be in a released egg!"
 msgstr "Das Package, in dem sich dieser Workflow befindet, scheint bereits released zu sein!"
 
-#: ./ftw/lawgiver/browser/templates/details.pt:212
+#: ./ftw/lawgiver/browser/templates/details.pt:222
 msgid "Translations"
 msgstr "Übersetzungen"
 
@@ -82,6 +86,10 @@ msgstr "locales-Verzeichnis"
 #: ./ftw/lawgiver/profiles.zcml:22
 msgid "Uninstall ftw.lawgiver"
 msgstr "ftw.lawgiver deinstallieren"
+
+#: ./ftw/lawgiver/browser/templates/details.pt:210
+msgid "Unknown permissions (neither ignored nor mapped)"
+msgstr "Unbekannte Berechtigungen (weder ignoriert noch auf eine Aktionsgruppe gemappt)"
 
 #: ./ftw/lawgiver/browser/templates/details.pt:198
 msgid "Unmanaged permissions"
@@ -193,13 +201,13 @@ msgid "edit"
 msgstr "bearbeiten"
 
 #. Default: "${id}: The specification file could not be parsed: ${error}"
-#: ./ftw/lawgiver/browser/details.py:187
-#: ./ftw/lawgiver/updater.py:197
+#: ./ftw/lawgiver/browser/details.py:188
+#: ./ftw/lawgiver/updater.py:199
 msgid "error_parsing_error"
 msgstr "${id}: Die Datei mit der Workflow-Spezifikation konnte nicht gelesen werden: ${error}"
 
 #. Default: "${id}: Error while generating the workflow: ${msg}"
-#: ./ftw/lawgiver/updater.py:145
+#: ./ftw/lawgiver/updater.py:147
 msgid "error_while_generating_workflow"
 msgstr "${id}: Fehler beim generieren des Workflows: ${msg}"
 
@@ -208,22 +216,22 @@ msgid "ftw.lawgiver"
 msgstr "ftw.lawgiver"
 
 #. Default: "${id}: The translations were updated in your locales directory. You should now run bin/i18n-build"
-#: ./ftw/lawgiver/updater.py:176
+#: ./ftw/lawgiver/updater.py:178
 msgid "info_locales_updated"
 msgstr "${id}: Die Übersetzungen wurden im locales-Verzeichnis aktualisiert. Jetzt sollte bin/i18n-build ausgeführt werden."
 
 #. Default: "Security update: ${amount} objects updated."
-#: ./ftw/lawgiver/browser/details.py:139
+#: ./ftw/lawgiver/browser/details.py:140
 msgid "info_security_updated"
 msgstr "Sicherheitsupdate: ${amount} Objekte wurden aktualisiert."
 
 #. Default: "${id}: The workflow was generated to ${path}."
-#: ./ftw/lawgiver/updater.py:158
+#: ./ftw/lawgiver/updater.py:160
 msgid "info_workflow_generated"
 msgstr "${id}: Der Workflow wurde generiert: ${path}."
 
 #. Default: "Workflow ${wfname} successfully imported."
-#: ./ftw/lawgiver/browser/details.py:128
+#: ./ftw/lawgiver/browser/details.py:129
 msgid "info_workflow_imported"
 msgstr "Der Workflow ${wfname} wurde auf dieser Plone-Seite installiert."
 

--- a/ftw/lawgiver/locales/ftw.lawgiver.pot
+++ b/ftw/lawgiver/locales/ftw.lawgiver.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2017-01-01 11:45+0000\n"
+"POT-Creation-Date: 2017-12-03 08:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "Could not find any information about this role."
 msgstr ""
 
-#: ./ftw/lawgiver/browser/templates/details.pt:221
+#: ./ftw/lawgiver/browser/templates/details.pt:231
 msgid "Default translations"
 msgstr ""
 
@@ -32,6 +32,10 @@ msgstr ""
 
 #: ./ftw/lawgiver/browser/templates/import-confirmation.pt:45
 msgid "I know what I am doing"
+msgstr ""
+
+#: ./ftw/lawgiver/browser/templates/details.pt:203
+msgid "Ignored permissions"
 msgstr ""
 
 #: ./ftw/lawgiver/browser/templates/import-confirmation.pt:26
@@ -66,7 +70,7 @@ msgstr ""
 msgid "Specification file:"
 msgstr ""
 
-#: ./ftw/lawgiver/browser/templates/details.pt:217
+#: ./ftw/lawgiver/browser/templates/details.pt:227
 msgid "Template"
 msgstr ""
 
@@ -74,7 +78,7 @@ msgstr ""
 msgid "The workflow seems to be in a released egg!"
 msgstr ""
 
-#: ./ftw/lawgiver/browser/templates/details.pt:212
+#: ./ftw/lawgiver/browser/templates/details.pt:222
 msgid "Translations"
 msgstr ""
 
@@ -84,6 +88,10 @@ msgstr ""
 
 #: ./ftw/lawgiver/profiles.zcml:22
 msgid "Uninstall ftw.lawgiver"
+msgstr ""
+
+#: ./ftw/lawgiver/browser/templates/details.pt:210
+msgid "Unknown permissions (neither ignored nor mapped)"
 msgstr ""
 
 #: ./ftw/lawgiver/browser/templates/details.pt:198
@@ -196,13 +204,13 @@ msgid "edit"
 msgstr ""
 
 #. Default: "${id}: The specification file could not be parsed: ${error}"
-#: ./ftw/lawgiver/browser/details.py:187
-#: ./ftw/lawgiver/updater.py:197
+#: ./ftw/lawgiver/browser/details.py:188
+#: ./ftw/lawgiver/updater.py:199
 msgid "error_parsing_error"
 msgstr ""
 
 #. Default: "${id}: Error while generating the workflow: ${msg}"
-#: ./ftw/lawgiver/updater.py:145
+#: ./ftw/lawgiver/updater.py:147
 msgid "error_while_generating_workflow"
 msgstr ""
 
@@ -211,22 +219,22 @@ msgid "ftw.lawgiver"
 msgstr ""
 
 #. Default: "${id}: The translations were updated in your locales directory. You should now run bin/i18n-build"
-#: ./ftw/lawgiver/updater.py:176
+#: ./ftw/lawgiver/updater.py:178
 msgid "info_locales_updated"
 msgstr ""
 
 #. Default: "Security update: ${amount} objects updated."
-#: ./ftw/lawgiver/browser/details.py:139
+#: ./ftw/lawgiver/browser/details.py:140
 msgid "info_security_updated"
 msgstr ""
 
 #. Default: "${id}: The workflow was generated to ${path}."
-#: ./ftw/lawgiver/updater.py:158
+#: ./ftw/lawgiver/updater.py:160
 msgid "info_workflow_generated"
 msgstr ""
 
 #. Default: "Workflow ${wfname} successfully imported."
-#: ./ftw/lawgiver/browser/details.py:128
+#: ./ftw/lawgiver/browser/details.py:129
 msgid "info_workflow_imported"
 msgstr ""
 

--- a/ftw/lawgiver/tests/pages/specdetails.py
+++ b/ftw/lawgiver/tests/pages/specdetails.py
@@ -35,8 +35,13 @@ def action_groups():
                                           action_group[1].css('li').text),
                     browser.css('dl.permission-mapping dd dl').first.items()))
 
-def unmanaged_permissions():
-    return browser.css('dl.unmanaged-permissions dd li').text
+
+def ignored_permissions():
+    return browser.css('dl.unmanaged-permissions .ignored-permissions li').text
+
+
+def unknown_permissions():
+    return browser.css('dl.unmanaged-permissions .unkown-permissions li').text
 
 
 def translations_pot():

--- a/ftw/lawgiver/tests/test_view_details.py
+++ b/ftw/lawgiver/tests/test_view_details.py
@@ -126,10 +126,10 @@ class TestBARSpecificationDetailsViewINSTALLED(TestCase):
     @browsing
     def test_unmanaged_permissions(self, browser):
         specdetails.visit('Bar Workflow (wf-bar)')
-        unmanaged = specdetails.unmanaged_permissions()
         self.assertIn(
-            'Plone Site Setup: Calendar', unmanaged,
-            'Expected permission to be unmanaged.')
+            'Plone Site Setup: Calendar', specdetails.ignored_permissions())
+        self.assertIn(
+            'Private, only accessible from trusted code', specdetails.unknown_permissions())
 
     @browsing
     def test_translations_pot(self, browser):


### PR DESCRIPTION
The unmapped permissions in the control panel are now split into two groups: permissions which are explicitly ignored and permissions which unknown: neither ignored nor mapped.
![bildschirmfoto 2017-12-04 um 08 31 06](https://user-images.githubusercontent.com/7469/33540979-9d666b6a-d8cd-11e7-8611-da283f34efb1.png)
