### PR TITLE
Ignore plone.restapi permissions because they are managed globally.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.11.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Ignore plone.restapi permissions because they are managed globally. [elioschmutz]
 
 
 1.11.0 (2017-12-06)

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -296,6 +296,8 @@
                      plone.cachepurging: Manually purge objects,
                      plone.resource: Export ZIP file,
                      plone.resourceeditor: Manage Sources,
+                     plone.restapi: Access Plone vocabularies,
+                     plone.restapi: Use REST API,
 
                      "
         />
@@ -326,7 +328,5 @@
                      view-permission,
                      "
         />
-
-
 
 </configure>


### PR DESCRIPTION
This PR ignores the `plone.restapi` permissions

They should be managed through the `rolemap.xml` globally.