### PR TITLE
Add new lawgiver:workflow directive.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,39 @@ especially the default ``lawgiver.zcml`` of ``ftw.lawgiver``.
     </configure>
 
 
+Workflow scope
+~~~~~~~~~~~~~~
+
+The ``lawgiver:workflow`` directive can be used to group multiple statements and
+apply them to a specific workflow.
+
+.. code:: xml
+
+    <configure
+        xmlns="http://namespaces.zope.org/zope"
+        xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
+        i18n_domain="my.package">
+
+      <include package="ftw.lawgiver" />
+
+      <lawgiver:workflow name="the-workflow">
+
+        <lawgiver:map_permissions
+            action_group="add folder"
+            permissions="Add folder"
+            />
+
+        <lawgiver:ignore
+            permissions="ATContentTypes: View history"
+            />
+
+      </lawgiver:workflow>
+
+    </configure>
+
+
+
+
 The workflow specification
 --------------------------
 

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.12.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add new lawgiver:workflow directive. [jone]
 
 
 1.12.0 (2017-12-15)

--- a/ftw/lawgiver/meta.py
+++ b/ftw/lawgiver/meta.py
@@ -14,6 +14,17 @@ from zope.schema import TextLine
 import zope.component.zcml
 
 
+class IWorkflowDirective(Interface):
+
+    name = TextLine(
+        title=u'The name of the workflow',
+        description=u'By default the directive contents'
+        u' apply to all workflows. Set the name of the'
+        u' workflow here for making it workflow specific.',
+        default=None,
+        required=True)
+
+
 class IMapPermissionsDirective(Interface):
 
     action_group = MessageID(
@@ -84,6 +95,20 @@ class ISharingPageRoleDirective(Interface):
         u'group "manage security".',
         required=False,
         default=True)
+
+
+class WorkflowContext(object):
+
+    def __init__(self, _context, name):
+        self.workflow = name
+
+    def ignore(self, _context, **kwargs):
+        kwargs['workflow'] = self.workflow
+        return ignorePermissions(_context, **kwargs)
+
+    def map_permissions(self, _context, **kwargs):
+        kwargs['workflow'] = self.workflow
+        return mapPermissions(_context, **kwargs)
 
 
 def mapPermissions(_context, **kwargs):

--- a/ftw/lawgiver/meta.zcml
+++ b/ftw/lawgiver/meta.zcml
@@ -4,6 +4,23 @@
 
   <meta:directives namespace="http://namespaces.zope.org/lawgiver">
 
+    <meta:complexDirective
+        name="workflow"
+        schema=".meta.IWorkflowDirective"
+        handler=".meta.WorkflowContext">
+
+      <meta:subdirective
+          name="map_permissions"
+          schema=".meta.IMapPermissionsDirective"
+          />
+
+      <meta:subdirective
+          name="ignore"
+          schema=".meta.IIgnorePermissionsDirective"
+          />
+
+    </meta:complexDirective>
+
     <meta:directive
         name="map_permissions"
         schema=".meta.IMapPermissionsDirective"

--- a/ftw/lawgiver/tests/test_actiongroups.py
+++ b/ftw/lawgiver/tests/test_actiongroups.py
@@ -396,3 +396,32 @@ class TestActionGroupRegistry(BaseTest):
              u'add ticket': set([u'Add ticket', u'Add portal content'])},
 
             registry.get_action_groups_for_workflow('custom'))
+
+    def test_workflow_scope_map_permissions(self):
+        self.load_map_permissions_zcml('''
+        <lawgiver:workflow name="the-workflow">
+            <lawgiver:map_permissions
+                action_group="view"
+                permissions="Access contents information"
+                />
+        </lawgiver:workflow>
+        ''')
+        registry = self.get_registry()
+        self.assertEqual(
+            registry.get_action_groups_for_workflow('the-workflow'),
+            {'view': set([u'Access contents information'])})
+        self.assertEqual(
+            registry.get_action_groups_for_workflow('other-workflow'),
+            {})
+
+    def test_workflow_scope_ignore(self):
+        self.load_map_permissions_zcml('''
+        <lawgiver:workflow name="the-workflow">
+            <lawgiver:ignore permissions="Access contents information" />
+        </lawgiver:workflow>
+        ''')
+        registry = self.get_registry()
+        self.assertIn(u'Access contents information',
+                      registry.get_ignored_permissions('the-workflow'))
+        self.assertNotIn(u'Access contents information',
+                         registry.get_ignored_permissions('other-workflow'))


### PR DESCRIPTION
The new lawgiver:workflow directive can be used for grouping statements for one workflow. The workflow attribute can be omitted in the nested ``map_permissions`` and ``ignore`` statements.

Example:
```xml
<configure
    xmlns="http://namespaces.zope.org/zope"
    xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
    i18n_domain="my.package">

  <include package="ftw.lawgiver" />

  <lawgiver:workflow name="the-workflow">

    <lawgiver:map_permissions
        action_group="add folder"
        permissions="Add folder"
        />

    <lawgiver:ignore
        permissions="ATContentTypes: View history"
        />

  </lawgiver:workflow>

</configure>
```