### PR TITLE
Fix encoding problems in sharing with non-ASCII roles.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Fix encoding problem when describing roles with non-ASCII characters titles. [jone]
 
 1.14.0 (2018-01-08)
 -------------------

--- a/ftw/lawgiver/browser/sharing.py
+++ b/ftw/lawgiver/browser/sharing.py
@@ -6,6 +6,7 @@ from ftw.lawgiver.utils import get_specification_for
 from ftw.lawgiver.utils import get_workflow_for
 from ftw.lawgiver.utils import merge_role_inheritance
 from plone.app.workflow.interfaces import ISharingPageRole
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import getUtilitiesFor
 from zope.component import getUtility
 from zope.i18n import translate
@@ -143,7 +144,7 @@ class SharingDescribeRole(BrowserView):
         and compare it to the text.
         """
 
-        translated_rolename = self.request.get('role', None)
+        translated_rolename = safe_unicode(self.request.get('role', None))
         if translated_rolename is None:
             return None
 

--- a/ftw/lawgiver/tests/locales/de/LC_MESSAGES/plone.po
+++ b/ftw/lawgiver/tests/locales/de/LC_MESSAGES/plone.po
@@ -33,7 +33,7 @@ msgstr "Alle"
 #. Default: "editor"
 #: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "my_custom_workflow--ROLE--Editor"
-msgstr "Redaktor"
+msgstr "Redaktör"
 
 #. Default: "system administrator"
 #: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt

--- a/ftw/lawgiver/tests/test_sharing_describe_roles.py
+++ b/ftw/lawgiver/tests/test_sharing_describe_roles.py
@@ -179,7 +179,7 @@ class TestSharingDescribeRoles(TestCase):
 
         browser.login().visit(page,
                               view='lawgiver-sharing-describe-role',
-                              data={'role': 'Redaktor'})
+                              data={'role': u'Redakt\xf6r'})
         table = browser.css('table').first.dicts()
 
         self.assertIn({'Aktion': 'Bearbeiten',


### PR DESCRIPTION
When opening the "describing"-overlay in the sharing view for a role with non-ASCII-characters in the title there was an encoding problem when comparing unicode with a bytestring.