### PR TITLE
Fix translation domains in ZCML files.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,7 @@ Changelog
 1.14.1 (unreleased)
 -------------------
 
+- Fix translation domains in ZCML files. [jone]
 - Fix encoding problem when describing roles with non-ASCII characters titles. [jone]
 
 1.14.0 (2018-01-08)

--- a/ftw/lawgiver/browser/configure.zcml
+++ b/ftw/lawgiver/browser/configure.zcml
@@ -1,6 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:browser="http://namespaces.zope.org/browser">
+    xmlns:browser="http://namespaces.zope.org/browser"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.lawgiver">
 
     <browser:resourceDirectory
         name="ftw.lawgiver-resources"

--- a/ftw/lawgiver/meta.zcml
+++ b/ftw/lawgiver/meta.zcml
@@ -1,6 +1,8 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
-    xmlns:meta="http://namespaces.zope.org/meta">
+    xmlns:meta="http://namespaces.zope.org/meta"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="ftw.lawgiver">
 
   <meta:directives namespace="http://namespaces.zope.org/lawgiver">
 

--- a/ftw/lawgiver/testing.py
+++ b/ftw/lawgiver/testing.py
@@ -78,7 +78,9 @@ class LawgiverLayer(PloneSandboxLayer):
         # example workflow test.
         xmlconfig.string(
             '<configure xmlns="http://namespaces.zope.org/zope"'
-            '           xmlns:lawgiver="http://namespaces.zope.org/lawgiver">'
+            '           xmlns:lawgiver="http://namespaces.zope.org/lawgiver"'
+            '           xmlns:i18n="http://namespaces.zope.org/i18n"'
+            '           i18n_domain="ftw.lawgiver">'
             '  <lawgiver:map_permissions'
             '      action_group="add folders"'
             '      permissions="Add portal content,'

--- a/ftw/lawgiver/tests/base.py
+++ b/ftw/lawgiver/tests/base.py
@@ -15,7 +15,9 @@ import unittest2
 
 
 CONFIGURE = '''
-<configure xmlns:lawgiver="http://namespaces.zope.org/lawgiver" i18n_domain="ftw.lawgiver">
+<configure xmlns:lawgiver="http://namespaces.zope.org/lawgiver"
+           xmlns:i18n="http://namespaces.zope.org/i18n"
+           i18n_domain="ftw.lawgiver">
 %s
 </configure>
 '''

--- a/ftw/lawgiver/tests/test_actiongroups.py
+++ b/ftw/lawgiver/tests/test_actiongroups.py
@@ -240,7 +240,7 @@ class TestActionGroupRegistry(BaseTest):
                 '                 View" />')
 
         self.assertEqual(
-            'File "<string>", line 3.0-6.25\n    ConfigurationError:'
+            'File "<string>", line 5.0-8.25\n    ConfigurationError:'
             ' Seems that a comma is missing in the "permissions" attribute'
             ' of the lawgiver:map_permissions tag.',
             str(cm.exception))

--- a/ftw/lawgiver/tests/tests.zcml
+++ b/ftw/lawgiver/tests/tests.zcml
@@ -1,5 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.lawgiver">
 
     <include package="Products.GenericSetup" file="meta.zcml" />

--- a/ftw/lawgiver/upgrades/configure.zcml
+++ b/ftw/lawgiver/upgrades/configure.zcml
@@ -1,7 +1,7 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
     xmlns:upgrade-step="http://namespaces.zope.org/ftw.upgrade"
-    i18n_domain="izug.organisation">
+    i18n_domain="ftw.lawgiver">
 
     <include package="ftw.upgrade" file="meta.zcml" />
 

--- a/ftw/lawgiver/wdl/configure.zcml
+++ b/ftw/lawgiver/wdl/configure.zcml
@@ -1,5 +1,6 @@
 <configure
     xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="ftw.lawgiver">
 
     <utility factory=".parser.SpecificationParser" />


### PR DESCRIPTION
Some ZCML files and ZCML strings (tests) had incomplete or wrong translation settings.

This eliminates this error in testing:
```
  Set up ftw.lawgiver.testing.LawgiverLayer /.../cache/eggs/zope.configuration-3.7.4-py2.7.egg/zope/configuration/fields.py:417: UserWarning: You did not specify an i18n translation domain for the 'action_group' field in <string>
  "'%s' field in %s" % (self.getName(), context.info.file )
```