### PR TITLE
Base class for custom modify status views.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,8 +5,7 @@ Changelog
 1.14.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
-
+- Provide a base class for implementing a custom modify status view. [jone]
 
 1.14.1 (2018-01-15)
 -------------------

--- a/ftw/lawgiver/browser/modifystatus.py
+++ b/ftw/lawgiver/browser/modifystatus.py
@@ -1,0 +1,78 @@
+from AccessControl import getSecurityManager
+from contextlib import contextmanager
+from DateTime import DateTime
+from Products.CMFCore.utils import getToolByName
+from zExceptions import BadRequest
+from zope.publisher.browser import BrowserView
+
+
+class ModifyStatusViewBase(BrowserView):
+    """The ModifyStatusViewBase is a base class for implementing custom behavior when excuting
+    workflow transitions.
+    See the readme for usage instructions.
+    """
+
+    def __call__(self):
+        transition = self.request.get('transition')
+        if not transition:
+            raise BadRequest('transition')
+
+        handler = self._interceptors.get(
+            transition, self.__class__.redirect_to_content_status_modify)
+        return handler(self, self.context, transition)
+
+    def execute_transition(self, context, transition, **kwargs):
+        kwargs['workflow_action'] = transition
+        return context.restrictedTraverse('content_status_modify')(**kwargs)
+
+    def redirect_to_content_status_modify(self, context, transition):
+        return self.request.response.redirect(
+            '{}/content_status_modify?workflow_action={}'.format(
+                context.absolute_url(), transition))
+
+    def set_workflow_state(self, context, review_state, **infos):
+        """Set the workflow status of the context to the given review state.
+        """
+        infos['review_state'] = review_state
+        infos.setdefault('action', '')
+        infos.setdefault('actor', getSecurityManager().getUser().getId())
+        infos.setdefault('time', DateTime())
+        infos.setdefault('comments', '')
+
+        portal_workflow = getToolByName(self.context, 'portal_workflow')
+        workflow_name = portal_workflow.getChainFor(context)[0]
+        portal_workflow.setStatusOf(workflow_name, context, infos)
+        for workflow in portal_workflow.getWorkflowsFor(context):
+            workflow.updateRoleMappingsFor(context)
+
+    @contextmanager
+    def in_state(self, context, review_state):
+        """Temporarily put the object in a certain review state in order to apply
+        changes with the security settings of the temporary state.
+        """
+        portal_workflow = getToolByName(self.context, 'portal_workflow')
+        ori_history = context.workflow_history
+        context.workflow_history = context.workflow_history.copy()
+        self.set_workflow_state(context, review_state)
+        try:
+            yield
+        finally:
+            context.workflow_history = ori_history
+            for workflow in portal_workflow.getWorkflowsFor(context):
+                workflow.updateRoleMappingsFor(context)
+
+    def redirect_to(self, context):
+        return self.request.response.redirect(context.absolute_url())
+
+    @classmethod
+    def intercept(cls, *transitions):
+        argname = '_interceptors'
+        if argname not in dir(cls):
+            setattr(cls, argname, {})
+
+        registry = getattr(cls, argname)
+        def decorator(func):
+            for transition_name in transitions:
+                registry[transition_name] = func
+            return func
+        return decorator

--- a/ftw/lawgiver/tests/test_modifystatus_view.py
+++ b/ftw/lawgiver/tests/test_modifystatus_view.py
@@ -1,0 +1,81 @@
+from Products.CMFCore.utils import getToolByName
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.lawgiver.browser.modifystatus import ModifyStatusViewBase
+from ftw.lawgiver.testing import LAWGIVER_INTEGRATION_TESTING
+from unittest2 import TestCase
+
+
+class TestModifyStatusViewBase(TestCase):
+    layer = LAWGIVER_INTEGRATION_TESTING
+
+    def setUp(self):
+        super(TestModifyStatusViewBase, self).setUp()
+        self.portal = self.layer['portal']
+        self.request = self.layer['request']
+        self.wftool = getToolByName(self.portal, 'portal_workflow')
+        self.wftool.setChainForPortalTypes(['Folder'], 'folder_workflow')
+
+    def test_can_intercept_transitions(self):
+        testcase = self
+        folder = create(Builder('folder'))
+
+        class MS(ModifyStatusViewBase):
+            @ModifyStatusViewBase.intercept('publish')
+            def abort_publication(self, context, transition):
+                testcase.assertEqual(folder, context)
+                testcase.assertEqual('publish', transition)
+                return 'intercepted...'
+
+        # the registered interception should be executed
+        self.request.set('transition', 'publish')
+        self.assertEqual('intercepted...', MS(folder, self.request)())
+
+        # but non-interecepted transition should be redirected to content_status_modify
+        self.assertIsNone(self.request.response.headers.get('location'))
+        self.request.set('transition', 'submit')
+        MS(folder, self.request)()
+        self.assertEqual(
+            '{}/content_status_modify?workflow_action=submit'.format(folder.absolute_url()),
+            self.request.response.headers.get('location'))
+
+    def test_execute_transition(self):
+        folder = create(Builder('folder'))
+        self.assertEqual('visible', self.wftool.getInfoFor(folder, 'review_state'))
+
+        ModifyStatusViewBase(folder, self.request).execute_transition(folder, 'publish')
+        self.assertEqual('published', self.wftool.getInfoFor(folder, 'review_state'))
+
+    def test_redirect_to_content_status_modify(self):
+        folder = create(Builder('folder'))
+        self.assertEqual('visible', self.wftool.getInfoFor(folder, 'review_state'))
+
+        ModifyStatusViewBase(folder, self.request).redirect_to_content_status_modify(
+            folder, 'publish')
+        self.assertEqual(
+            '{}/content_status_modify?workflow_action=publish'.format(folder.absolute_url()),
+            self.request.response.headers.get('location'))
+        self.assertEqual('visible', self.wftool.getInfoFor(folder, 'review_state'))
+
+    def test_set_workflow_state(self):
+        folder = create(Builder('folder'))
+        self.assertEqual('visible', self.wftool.getInfoFor(folder, 'review_state'))
+
+        ModifyStatusViewBase(folder, self.request).set_workflow_state(folder, 'published')
+        self.assertEqual('published', self.wftool.getInfoFor(folder, 'review_state'))
+
+    def test_in_state(self):
+        folder = create(Builder('folder'))
+        self.assertEqual('visible', self.wftool.getInfoFor(folder, 'review_state'))
+
+        with ModifyStatusViewBase(folder, self.request).in_state(folder, 'published'):
+            self.assertEqual('published', self.wftool.getInfoFor(folder, 'review_state'))
+
+        self.assertEqual('visible', self.wftool.getInfoFor(folder, 'review_state'))
+
+    def test_redirect_to(self):
+        folder = create(Builder('folder'))
+        self.assertIsNone(self.request.response.headers.get('location'))
+
+        ModifyStatusViewBase(folder, self.request).redirect_to(folder)
+        self.assertEqual(folder.absolute_url(), self.request.response.headers.get('location'))


### PR DESCRIPTION
The new ModifyStatusViewBase makes it easy to implement custom behavior when executing transitions. It provides the most common functionality for intercepting, enhancing and changing the execution of transitions.

See the readme for further description and example code.