### PR TITLE
Simplify (and shorten) status id

### DIFF
--- a/ftw/lawgiver/generator.py
+++ b/ftw/lawgiver/generator.py
@@ -351,8 +351,7 @@ class WorkflowGenerator(object):
             self._normalize(transition.dest_status.title))
 
     def _status_id(self, status):
-        return '%s--STATUS--%s' % (
-            self.workflow_id, self._normalize(status.title))
+        return self._normalize(status.title)
 
     def _role_id(self, role):
         return generate_role_translation_id(self.workflow_id, role)


### PR DESCRIPTION
Hi @jone, how's it going?

is there any reason we can't do this?

Reasons to do it:
  - clearer status for tabular view of folders/collections
  - e.g. "published" state unifies with other workflows when constructing a workflow with a review_state criteria