### PR TITLE
Downgrade ftw.testing for now.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ tests_require = [
     'Zope2',
     'ftw.builder',
     'ftw.testbrowser',
-    'ftw.testing',
+    'ftw.testing<2a',
     'plone.app.contenttypes',
     'plone.app.testing',
     'plone.browserlayer',


### PR DESCRIPTION
The tests of ftw.lawgiver are currently not working with ftw.testing=2.0.0.
We are downgrading the dependency here so that the tests work again.
When the problem is fixed in ftw.testing we can upgrade again.

See also: #90

/ cc @buchi 