### PR TITLE
Ignore ATContentTypes permissions by default in Plone 5.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,10 +2,10 @@ Changelog
 =========
 
 
-1.16.2 (unreleased)
+1.17.0 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Ignore ATContentTypes permissions by default in Plone 5. [jone]
 
 
 1.16.1 (2019-09-12)

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -55,14 +55,6 @@
     <lawgiver:map_permissions
         action_group="add"
         permissions="
-                     ATContentTypes: Add Document,
-                     ATContentTypes: Add Event,
-                     ATContentTypes: Add File,
-                     ATContentTypes: Add Folder,
-                     ATContentTypes: Add Image,
-                     ATContentTypes: Add Large Plone Folder,
-                     ATContentTypes: Add Link,
-                     ATContentTypes: Add News Item,
                      Add Folders,
                      Add portal content,
                      Add portal events,
@@ -80,6 +72,38 @@
                      plone.app.contenttypes: Add News Item
                      "
         />
+
+    <configure zcml:condition="have plone-4">
+      <lawgiver:map_permissions
+          action_group="add"
+          permissions="
+                       ATContentTypes: Add Document,
+                       ATContentTypes: Add Event,
+                       ATContentTypes: Add File,
+                       ATContentTypes: Add Folder,
+                       ATContentTypes: Add Image,
+                       ATContentTypes: Add Large Plone Folder,
+                       ATContentTypes: Add Link,
+                       ATContentTypes: Add News Item
+                       "
+          />
+    </configure>
+
+    <configure zcml:condition="have plone-5">
+      <lawgiver:ignore
+          permissions="
+                       ATContentTypes: Add Document,
+                       ATContentTypes: Add Event,
+                       ATContentTypes: Add File,
+                       ATContentTypes: Add Folder,
+                       ATContentTypes: Add Image,
+                       ATContentTypes: Add Large Plone Folder,
+                       ATContentTypes: Add Link,
+                       ATContentTypes: Add News Item
+                       "
+          />
+    </configure>
+
 
 
     <configure zcml:condition="installed collective.deletepermission">

--- a/ftw/lawgiver/tests/assets/example-5.1.0-deletepermission/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-5.1.0-deletepermission/definition.xml
@@ -1,13 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dc-workflow workflow_id="example-5.1.0-deletepermission" title="My Custom Workflow" description="A three state publication workflow" initial_state="example-5.1.0-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
-  <permission>ATContentTypes: Add Document</permission>
-  <permission>ATContentTypes: Add Event</permission>
-  <permission>ATContentTypes: Add File</permission>
-  <permission>ATContentTypes: Add Folder</permission>
-  <permission>ATContentTypes: Add Image</permission>
-  <permission>ATContentTypes: Add Large Plone Folder</permission>
-  <permission>ATContentTypes: Add Link</permission>
-  <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
@@ -55,38 +47,6 @@
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--retract--pending_private"/>
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--publish--pending_published"/>
-    <permission-map name="ATContentTypes: Add Document" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Event" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add File" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Link" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add News Item" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -234,38 +194,6 @@
   <state state_id="example-5.1.0-deletepermission--STATUS--private" title="Private">
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--publish--private_published"/>
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--submit-for-publication--private_pending"/>
-    <permission-map name="ATContentTypes: Add Document" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Event" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add File" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Link" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add News Item" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -423,38 +351,6 @@
   </state>
   <state state_id="example-5.1.0-deletepermission--STATUS--published" title="Published">
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--retract--published_private"/>
-    <permission-map name="ATContentTypes: Add Document" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Event" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add File" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Link" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add News Item" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Anonymous</permission-role>
       <permission-role>Editor</permission-role>

--- a/ftw/lawgiver/tests/assets/example-5.1.0-no-deletepermission/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-5.1.0-no-deletepermission/definition.xml
@@ -1,13 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <dc-workflow workflow_id="example-5.1.0-no-deletepermission" title="My Custom Workflow" description="A three state publication workflow" initial_state="example-5.1.0-no-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
-  <permission>ATContentTypes: Add Document</permission>
-  <permission>ATContentTypes: Add Event</permission>
-  <permission>ATContentTypes: Add File</permission>
-  <permission>ATContentTypes: Add Folder</permission>
-  <permission>ATContentTypes: Add Image</permission>
-  <permission>ATContentTypes: Add Large Plone Folder</permission>
-  <permission>ATContentTypes: Add Link</permission>
-  <permission>ATContentTypes: Add News Item</permission>
   <permission>Access contents information</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
@@ -54,38 +46,6 @@
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--retract--pending_private"/>
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--publish--pending_published"/>
-    <permission-map name="ATContentTypes: Add Document" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Event" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add File" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Link" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add News Item" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -229,38 +189,6 @@
   <state state_id="example-5.1.0-no-deletepermission--STATUS--private" title="Private">
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--publish--private_published"/>
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--submit-for-publication--private_pending"/>
-    <permission-map name="ATContentTypes: Add Document" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Event" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add File" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Link" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add News Item" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Reviewer</permission-role>
@@ -414,38 +342,6 @@
   </state>
   <state state_id="example-5.1.0-no-deletepermission--STATUS--published" title="Published">
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--retract--published_private"/>
-    <permission-map name="ATContentTypes: Add Document" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Event" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add File" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Large Plone Folder" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add Link" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="ATContentTypes: Add News Item" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Anonymous</permission-role>
       <permission-role>Editor</permission-role>


### PR DESCRIPTION
Although Archetypes and ATContentTypes is still there under Plone 5 it is no logner the standard. plone.app.contenttypes, the Dexterity types, should be used with Plone 5.

In order to clean up our workflows for Plone 5, the default behavior of ftw.lawgiver is changed so that the ATContentTypes permissions are ignored by default under Plone 5.

Users which still use ATContentTypes under Plone 5 may override the action group mapping in their policy package.

At 4teamwork, are not using ATContentTypes under Plone 5 and we are not going to use it in the future.