### PR TITLE
Testing: improve diff output in workflow test for unittest

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.17.2 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Testing: improve diff output in workflow test for unittest. [jone]
 
 
 1.17.1 (2019-11-22)


### PR DESCRIPTION
We have switched from unittest2 to unittest recently. Both have a "assertMultiLineEqual", but the latter does handle large datasets very well: unittest.assertMultiLineEqual just displays all on one line when a definition.xml is diffed; what we do.

Therefore the XML diffing is reimplemented so that a unified diff is printed in multiple lines so that the assertion message is readable again for a human being.

#### before
<img width="2414" alt="Bildschirmfoto 2019-11-28 um 17 54 09" src="https://user-images.githubusercontent.com/7469/69823057-218abc00-1208-11ea-9781-74de3abeec50.png">

#### after
<img width="2414" alt="Bildschirmfoto 2019-11-28 um 17 54 20" src="https://user-images.githubusercontent.com/7469/69823068-25b6d980-1208-11ea-9ae7-d220450a06f1.png">
