### PR TITLE
Fix bug for sharing view over REST-API.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.17.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix bug for sharing view over REST-API. [njohner]
 
 
 1.17.2 (2019-11-28)

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -326,6 +326,7 @@
                      plone.cachepurging: Manually purge objects,
                      plone.resource: Export ZIP file,
                      plone.resourceeditor: Manage Sources,
+                     plone.restapi: Access Plone user information,
                      plone.restapi: Access Plone vocabularies,
                      plone.restapi: Use REST API,
 

--- a/ftw/lawgiver/tests/base.py
+++ b/ftw/lawgiver/tests/base.py
@@ -299,6 +299,7 @@ class WorkflowTest(XMLDiffTestCase):
                 unmapped.append(permission)
 
         self.maxDiff = None
+        self.longMessage = True
         self.assertEquals(
             [], unmapped,
             'There are permissions which are not yet mapped'

--- a/ftw/lawgiver/tests/pages/sharing.py
+++ b/ftw/lawgiver/tests/pages/sharing.py
@@ -7,5 +7,16 @@ def visit(obj):
     browser.open(obj, view='sharing')
 
 
+def visit_api(obj):
+    browser.login(SITE_OWNER_NAME)
+    browser.open(
+        obj,
+        view='sharing',
+        headers={
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+        })
+
+
 def role_labels():
     return browser.css('#user-group-sharing-head th').text[1:]

--- a/ftw/lawgiver/tests/test_sharing.py
+++ b/ftw/lawgiver/tests/test_sharing.py
@@ -42,6 +42,19 @@ class TestSharingRoleTranslation(TestCase):
             ['Can add', 'Can view', 'editor', 'editor-in-chief'],
             sharing.role_labels())
 
+    @browsing
+    def test_custom_role_translation_per_workflow_over_restapi(self, browser):
+        applyProfile(self.portal, 'ftw.lawgiver.tests:role-translation')
+        wftool = getToolByName(self.portal, 'portal_workflow')
+        wftool.setChainForPortalTypes(['Document'], 'role-translation')
+
+        document = create(Builder('document'))
+        sharing.visit_api(document)
+
+        self.assertEquals(
+            ['Can add', 'Can view', 'editor', 'editor-in-chief'],
+            sharing.role_labels())
+
     def test_custom_role_translation_per_workflow_when_context_is_view(self):
         # Dependenging on what is traversed, the role utility may guess
         # the view from the request as context.

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ tests_require = [
     'plone.app.testing',
     'plone.browserlayer',
     'plone.mocktestcase',
+    'plone.api',
     'plone.restapi',
     'plone.testing',
     'transaction',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ tests_require = [
     'plone.app.testing',
     'plone.browserlayer',
     'plone.mocktestcase',
+    'plone.restapi',
     'plone.testing',
     'transaction',
     'zope.configuration',

--- a/test-plone-4.3.x-deletepermission.cfg
+++ b/test-plone-4.3.x-deletepermission.cfg
@@ -5,3 +5,9 @@ extends =
 
 package-name = ftw.lawgiver
 test-extras = tests, deletepermission
+
+[versions]
+# plone.restapi indirectly import zipp
+# (plone.schema -> jsonschema -> importlib-metadata -> zipp)
+# and zipp version 0.6 is not python 3 compatible, though it claims to be
+zipp = 0.5.2

--- a/test-plone-4.3.x-no-deletepermission.cfg
+++ b/test-plone-4.3.x-no-deletepermission.cfg
@@ -4,3 +4,9 @@ extends =
     sources.cfg
 
 package-name = ftw.lawgiver
+
+[versions]
+# plone.restapi indirectly import zipp
+# (plone.schema -> jsonschema -> importlib-metadata -> zipp)
+# and zipp version 0.6 is not python 3 compatible, though it claims to be
+zipp = 0.5.2


### PR DESCRIPTION
Lawgiver did not work correctly when combined with the REST-API. Indeed in the `DynamicRolesUtility` the context is retrieved from the traversed objects (`request.PARENTS[0]`), which, when the sharing endpoint is called through the REST-API,  is a `RESTWrapper` object and not the object itself. `RESTWrapper` normally delegates everything to `self.context`, but this does not work for certain magic methods, like `__provides__`, which breaks `get_workflow_for` in `DynamicRolesAdapter`. This is fixed here by passing the object itself instead of `RESTWrapper`.

We also needed to pin `zipp` which is an indirect dependency of `plone.restapi` and its latest version is not python 2 compatible.

This is for https://github.com/4teamwork/opengever.core/issues/6041