### PR TITLE
Revert "Normalize workflow values."

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,9 +5,7 @@ Changelog
 1.17.4 (unreleased)
 -------------------
 
-- Normalize titles due to translation in plone.app.content starting with tag 3.4.4:
-  https://github.com/plone/plone.app.content/blob/ab2e5d77ad5f779de04f49631fec4079a1577f48/plone/app/content/browser/contents/workflow.py#L60
-  [busykoala]
+- Nothing changed yet.
 
 
 1.17.3 (2019-12-10)

--- a/ftw/lawgiver/generator.py
+++ b/ftw/lawgiver/generator.py
@@ -8,7 +8,7 @@ from ftw.lawgiver.variables import VARIABLES
 from lxml import etree
 from lxml import html
 from plone.app.workflow.interfaces import ISharingPageRole
-from plone.i18n.normalizer import idnormalizer
+from plone.i18n.normalizer.interfaces import INormalizer
 from zope.component import getUtilitiesFor
 from zope.component import getUtility
 from zope.i18n import translate
@@ -117,7 +117,7 @@ class WorkflowGenerator(object):
     def _create_document(self):
         root = etree.Element("dc-workflow")
         root.set('workflow_id', self.workflow_id)
-        root.set('title', idnormalizer.normalize(self.specification.title.decode('utf-8')))
+        root.set('title', self.specification.title.decode('utf-8'))
         root.set('description', self.specification.description and
                  self.specification.description.decode('utf-8') or '')
 
@@ -136,7 +136,7 @@ class WorkflowGenerator(object):
     def _add_status(self, doc, status):
         node = etree.SubElement(doc, 'state')
         node.set('state_id', self._status_id(status))
-        node.set('title', idnormalizer.normalize(status.title.decode('utf-8')))
+        node.set('title', status.title.decode('utf-8'))
 
         for transition in self.specification.transitions:
             assert transition.src_status is not None, \
@@ -153,8 +153,7 @@ class WorkflowGenerator(object):
         node = etree.SubElement(doc, 'transition')
 
         node.set('new_state', self._status_id(transition.dest_status))
-
-        node.set('title', idnormalizer.normalize(transition.title.decode('utf-8')))
+        node.set('title', transition.title.decode('utf-8'))
         node.set('transition_id', self._transition_id(transition))
 
         node.set('after_script', '')
@@ -171,7 +170,7 @@ class WorkflowGenerator(object):
 
         action.set('url', url_struct % {
                 'transition': self._transition_id(transition)})
-        action.text = idnormalizer.normalize(transition.title.decode('utf-8'))
+        action.text = transition.title.decode('utf-8')
 
         return node
 
@@ -262,7 +261,7 @@ class WorkflowGenerator(object):
         action.set('icon', '')
         action.set('url', '%%(portal_url)s/search?review_state=%s' % (
                 self._status_id(status)))
-        action.text = '%s (%%(count)d)' % idnormalizer.normalize(status.title.decode('utf-8'))
+        action.text = '%s (%%(count)d)' % status.title.decode('utf-8')
 
         match = etree.SubElement(worklist, 'match')
         match.set('name', 'review_state')
@@ -369,7 +368,10 @@ class WorkflowGenerator(object):
     def _normalize(self, text):
         if isinstance(text, str):
             text = text.decode('utf-8')
-        return idnormalizer.normalize(text)
+
+        normalizer = getUtility(INormalizer)
+        result = normalizer.normalize(text)
+        return result.decode('utf-8')
 
     def _translate_action_group(self, action_group, language):
         zcml_domain = translate(action_group, target_language=language)

--- a/ftw/lawgiver/i18nbuilder.py
+++ b/ftw/lawgiver/i18nbuilder.py
@@ -5,7 +5,6 @@ from i18ndude.catalog import MessageCatalog
 from i18ndude.catalog import POWriter
 from operator import attrgetter
 from path import Path
-from plone.i18n.normalizer import idnormalizer
 from zope.component import getUtility
 import os.path
 
@@ -126,7 +125,7 @@ class I18nBuilder(object):
                                        catalog.values()))
 
         for msgid, msgstr in translations.items():
-            msgid = idnormalizer.normalize(msgid)
+            msgid = msgid.decode('utf-8').replace('"', '\\"')
             msgstr = msgstr.decode('utf-8').replace('"', '\\"')
 
             if msgid in delete_candidates:

--- a/ftw/lawgiver/tests/assets/example-4.3.5-deletepermission/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.3.5-deletepermission/definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<dc-workflow workflow_id="example-4.3.5-deletepermission" title="my-custom-workflow" description="A three state publication workflow" initial_state="example-4.3.5-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
+<dc-workflow workflow_id="example-4.3.5-deletepermission" title="My Custom Workflow" description="A three state publication workflow" initial_state="example-4.3.5-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
   <permission>ATContentTypes: Add Document</permission>
   <permission>ATContentTypes: Add Event</permission>
   <permission>ATContentTypes: Add File</permission>
@@ -50,7 +50,7 @@
   <permission>plone.app.event: Import Ical</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
-  <state state_id="example-4.3.5-deletepermission--STATUS--pending" title="pending">
+  <state state_id="example-4.3.5-deletepermission--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-4.3.5-deletepermission--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-4.3.5-deletepermission--TRANSITION--retract--pending_private"/>
     <exit-transition transition_id="example-4.3.5-deletepermission--TRANSITION--publish--pending_published"/>
@@ -229,7 +229,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-4.3.5-deletepermission--STATUS--private" title="private">
+  <state state_id="example-4.3.5-deletepermission--STATUS--private" title="Private">
     <exit-transition transition_id="example-4.3.5-deletepermission--TRANSITION--publish--private_published"/>
     <exit-transition transition_id="example-4.3.5-deletepermission--TRANSITION--submit-for-publication--private_pending"/>
     <permission-map name="ATContentTypes: Add Document" acquired="False">
@@ -418,7 +418,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-4.3.5-deletepermission--STATUS--published" title="published">
+  <state state_id="example-4.3.5-deletepermission--STATUS--published" title="Published">
     <exit-transition transition_id="example-4.3.5-deletepermission--TRANSITION--retract--published_private"/>
     <permission-map name="ATContentTypes: Add Document" acquired="False">
       <permission-role>Editor</permission-role>
@@ -620,8 +620,8 @@
       <guard-role>Editor</guard-role>
     </guard>
   </transition>
-  <transition new_state="example-4.3.5-deletepermission--STATUS--pending" title="submit-for-publication" transition_id="example-4.3.5-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.3.5-deletepermission--TRANSITION--submit-for-publication--private_pending">submit-for-publication</action>
+  <transition new_state="example-4.3.5-deletepermission--STATUS--pending" title="submit for publication" transition_id="example-4.3.5-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.3.5-deletepermission--TRANSITION--submit-for-publication--private_pending">submit for publication</action>
     <guard>
       <guard-role>Editor</guard-role>
     </guard>

--- a/ftw/lawgiver/tests/assets/example-4.3.5-no-deletepermission/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-4.3.5-no-deletepermission/definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<dc-workflow workflow_id="example-4.3.5-no-deletepermission" title="my-custom-workflow" description="A three state publication workflow" initial_state="example-4.3.5-no-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
+<dc-workflow workflow_id="example-4.3.5-no-deletepermission" title="My Custom Workflow" description="A three state publication workflow" initial_state="example-4.3.5-no-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
   <permission>ATContentTypes: Add Document</permission>
   <permission>ATContentTypes: Add Event</permission>
   <permission>ATContentTypes: Add File</permission>
@@ -49,7 +49,7 @@
   <permission>plone.app.event: Import Ical</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
-  <state state_id="example-4.3.5-no-deletepermission--STATUS--pending" title="pending">
+  <state state_id="example-4.3.5-no-deletepermission--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-4.3.5-no-deletepermission--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-4.3.5-no-deletepermission--TRANSITION--retract--pending_private"/>
     <exit-transition transition_id="example-4.3.5-no-deletepermission--TRANSITION--publish--pending_published"/>
@@ -224,7 +224,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-4.3.5-no-deletepermission--STATUS--private" title="private">
+  <state state_id="example-4.3.5-no-deletepermission--STATUS--private" title="Private">
     <exit-transition transition_id="example-4.3.5-no-deletepermission--TRANSITION--publish--private_published"/>
     <exit-transition transition_id="example-4.3.5-no-deletepermission--TRANSITION--submit-for-publication--private_pending"/>
     <permission-map name="ATContentTypes: Add Document" acquired="False">
@@ -409,7 +409,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-4.3.5-no-deletepermission--STATUS--published" title="published">
+  <state state_id="example-4.3.5-no-deletepermission--STATUS--published" title="Published">
     <exit-transition transition_id="example-4.3.5-no-deletepermission--TRANSITION--retract--published_private"/>
     <permission-map name="ATContentTypes: Add Document" acquired="False">
       <permission-role>Editor</permission-role>
@@ -607,8 +607,8 @@
       <guard-role>Editor</guard-role>
     </guard>
   </transition>
-  <transition new_state="example-4.3.5-no-deletepermission--STATUS--pending" title="submit-for-publication" transition_id="example-4.3.5-no-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.3.5-no-deletepermission--TRANSITION--submit-for-publication--private_pending">submit-for-publication</action>
+  <transition new_state="example-4.3.5-no-deletepermission--STATUS--pending" title="submit for publication" transition_id="example-4.3.5-no-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-4.3.5-no-deletepermission--TRANSITION--submit-for-publication--private_pending">submit for publication</action>
     <guard>
       <guard-role>Editor</guard-role>
     </guard>

--- a/ftw/lawgiver/tests/assets/example-5.1.0-deletepermission/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-5.1.0-deletepermission/definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<dc-workflow workflow_id="example-5.1.0-deletepermission" title="my-custom-workflow" description="A three state publication workflow" initial_state="example-5.1.0-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
+<dc-workflow workflow_id="example-5.1.0-deletepermission" title="My Custom Workflow" description="A three state publication workflow" initial_state="example-5.1.0-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
   <permission>Access contents information</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
@@ -43,7 +43,7 @@
   <permission>plone.app.multilingual: Manage Translations</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
-  <state state_id="example-5.1.0-deletepermission--STATUS--pending" title="pending">
+  <state state_id="example-5.1.0-deletepermission--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--retract--pending_private"/>
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--publish--pending_published"/>
@@ -191,7 +191,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-5.1.0-deletepermission--STATUS--private" title="private">
+  <state state_id="example-5.1.0-deletepermission--STATUS--private" title="Private">
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--publish--private_published"/>
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--submit-for-publication--private_pending"/>
     <permission-map name="Access contents information" acquired="False">
@@ -349,7 +349,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-5.1.0-deletepermission--STATUS--published" title="published">
+  <state state_id="example-5.1.0-deletepermission--STATUS--published" title="Published">
     <exit-transition transition_id="example-5.1.0-deletepermission--TRANSITION--retract--published_private"/>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Anonymous</permission-role>
@@ -520,8 +520,8 @@
       <guard-role>Editor</guard-role>
     </guard>
   </transition>
-  <transition new_state="example-5.1.0-deletepermission--STATUS--pending" title="submit-for-publication" transition_id="example-5.1.0-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-5.1.0-deletepermission--TRANSITION--submit-for-publication--private_pending">submit-for-publication</action>
+  <transition new_state="example-5.1.0-deletepermission--STATUS--pending" title="submit for publication" transition_id="example-5.1.0-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-5.1.0-deletepermission--TRANSITION--submit-for-publication--private_pending">submit for publication</action>
     <guard>
       <guard-role>Editor</guard-role>
     </guard>

--- a/ftw/lawgiver/tests/assets/example-5.1.0-no-deletepermission/definition.xml
+++ b/ftw/lawgiver/tests/assets/example-5.1.0-no-deletepermission/definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<dc-workflow workflow_id="example-5.1.0-no-deletepermission" title="my-custom-workflow" description="A three state publication workflow" initial_state="example-5.1.0-no-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
+<dc-workflow workflow_id="example-5.1.0-no-deletepermission" title="My Custom Workflow" description="A three state publication workflow" initial_state="example-5.1.0-no-deletepermission--STATUS--private" state_variable="review_state" manager_bypass="True">
   <permission>Access contents information</permission>
   <permission>Add Folders</permission>
   <permission>Add portal content</permission>
@@ -42,7 +42,7 @@
   <permission>plone.app.multilingual: Manage Translations</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
-  <state state_id="example-5.1.0-no-deletepermission--STATUS--pending" title="pending">
+  <state state_id="example-5.1.0-no-deletepermission--STATUS--pending" title="Pending">
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--reject--pending_private"/>
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--retract--pending_private"/>
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--publish--pending_published"/>
@@ -186,7 +186,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-5.1.0-no-deletepermission--STATUS--private" title="private">
+  <state state_id="example-5.1.0-no-deletepermission--STATUS--private" title="Private">
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--publish--private_published"/>
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--submit-for-publication--private_pending"/>
     <permission-map name="Access contents information" acquired="False">
@@ -340,7 +340,7 @@
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>
-  <state state_id="example-5.1.0-no-deletepermission--STATUS--published" title="published">
+  <state state_id="example-5.1.0-no-deletepermission--STATUS--published" title="Published">
     <exit-transition transition_id="example-5.1.0-no-deletepermission--TRANSITION--retract--published_private"/>
     <permission-map name="Access contents information" acquired="False">
       <permission-role>Anonymous</permission-role>
@@ -507,8 +507,8 @@
       <guard-role>Editor</guard-role>
     </guard>
   </transition>
-  <transition new_state="example-5.1.0-no-deletepermission--STATUS--pending" title="submit-for-publication" transition_id="example-5.1.0-no-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-5.1.0-no-deletepermission--TRANSITION--submit-for-publication--private_pending">submit-for-publication</action>
+  <transition new_state="example-5.1.0-no-deletepermission--STATUS--pending" title="submit for publication" transition_id="example-5.1.0-no-deletepermission--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
+    <action category="workflow" icon="" url="%(content_url)s/content_status_modify?workflow_action=example-5.1.0-no-deletepermission--TRANSITION--submit-for-publication--private_pending">submit for publication</action>
     <guard>
       <guard-role>Editor</guard-role>
     </guard>

--- a/ftw/lawgiver/tests/assets/example.definition.xml
+++ b/ftw/lawgiver/tests/assets/example.definition.xml
@@ -1,187 +1,196 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<dc-workflow workflow_id="my_custom_workflow" title="my-custom-workflow" description="A three state publication workflow" initial_state="my_custom_workflow--STATUS--private" state_variable="review_state" manager_bypass="True">
-  <permission>ATContentTypes: Add Image</permission>
-  <permission>Access contents information</permission>
-  <permission>Add portal content</permission>
-  <permission>Delete objects</permission>
-  <permission>Modify portal content</permission>
-  <permission>View</permission>
-  <state state_id="my_custom_workflow--STATUS--pending" title="pending">
-    <exit-transition transition_id="my_custom_workflow--TRANSITION--reject--pending_private"/>
-    <exit-transition transition_id="my_custom_workflow--TRANSITION--retract--pending_private"/>
-    <exit-transition transition_id="my_custom_workflow--TRANSITION--publish--pending_published"/>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Access contents information" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="Delete objects" acquired="False">
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="View" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-  </state>
-  <state state_id="my_custom_workflow--STATUS--private" title="private">
-    <exit-transition transition_id="my_custom_workflow--TRANSITION--publish--private_published"/>
-    <exit-transition transition_id="my_custom_workflow--TRANSITION--submit-for-publication--private_pending"/>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Access contents information" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="Delete objects" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="View" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-  </state>
-  <state state_id="my_custom_workflow--STATUS--published" title="published">
-    <exit-transition transition_id="my_custom_workflow--TRANSITION--retract--published_private"/>
-    <permission-map name="ATContentTypes: Add Image" acquired="False">
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Access contents information" acquired="False">
-      <permission-role>Anonymous</permission-role>
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Add portal content" acquired="False">
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-    </permission-map>
-    <permission-map name="Delete objects" acquired="False">
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="Modify portal content" acquired="False">
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-    <permission-map name="View" acquired="False">
-      <permission-role>Anonymous</permission-role>
-      <permission-role>Editor</permission-role>
-      <permission-role>Reviewer</permission-role>
-      <permission-role>Site Administrator</permission-role>
-    </permission-map>
-  </state>
-  <transition new_state="my_custom_workflow--STATUS--published" title="publish" transition_id="my_custom_workflow--TRANSITION--publish--private_published" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--publish--private_published">publish</action>
-    <guard>
-      <guard-role>Site Administrator</guard-role>
-      <guard-role>Reviewer</guard-role>
-    </guard>
-  </transition>
-  <transition new_state="my_custom_workflow--STATUS--published" title="publish" transition_id="my_custom_workflow--TRANSITION--publish--pending_published" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--publish--pending_published">publish</action>
-    <guard>
-      <guard-role>Site Administrator</guard-role>
-      <guard-role>Reviewer</guard-role>
-      <guard-expression>here/transition_guard_pending_published</guard-expression>
-    </guard>
-  </transition>
-  <transition new_state="my_custom_workflow--STATUS--private" title="reject" transition_id="my_custom_workflow--TRANSITION--reject--pending_private" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--reject--pending_private">reject</action>
-    <guard>
-      <guard-role>Reviewer</guard-role>
-    </guard>
-  </transition>
-  <transition new_state="my_custom_workflow--STATUS--private" title="retract" transition_id="my_custom_workflow--TRANSITION--retract--pending_private" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--retract--pending_private">retract</action>
-    <guard>
-      <guard-role>Editor</guard-role>
-      <guard-expression>python:here.guard(state_change)</guard-expression>
-    </guard>
-  </transition>
-  <transition new_state="my_custom_workflow--STATUS--private" title="retract" transition_id="my_custom_workflow--TRANSITION--retract--published_private" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--retract--published_private">retract</action>
-    <guard>
-      <guard-role>Reviewer</guard-role>
-      <guard-role>Editor</guard-role>
-    </guard>
-  </transition>
-  <transition new_state="my_custom_workflow--STATUS--pending" title="submit-for-publication" transition_id="my_custom_workflow--TRANSITION--submit-for-publication--private_pending" after_script="" before_script="" trigger="USER">
-    <action category="workflow" icon="" url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--submit-for-publication--private_pending">submit-for-publication</action>
-    <guard>
-      <guard-role>Editor</guard-role>
-    </guard>
-  </transition>
-  <worklist title="" worklist_id="my_custom_workflow--WORKLIST--pending">
-    <action category="global" icon="" url="%(portal_url)s/search?review_state=my_custom_workflow--STATUS--pending">pending (%(count)d)</action>
-    <match name="review_state" values="my_custom_workflow--STATUS--pending"/>
-    <guard>
-      <guard-role>Reviewer</guard-role>
-    </guard>
-  </worklist>
-  <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
-    <description>Previous transition</description>
-    <default>
-        <expression>transition/getId|nothing</expression>
-    </default>
-    <guard/>
-</variable>
-  <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
-<description>The ID of the user who performed the previous transition</description>
-    <default>
-        <expression>user/getId</expression>
-    </default>
-    <guard/>
-</variable>
-  <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
-    <description>Comment about the last transition</description>
-    <default>
-        <expression>python:state_change.kwargs.get('comment', '')</expression>
-    </default>
-    <guard/>
-</variable>
-  <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
-    <description>Provides access to workflow history</description>
-    <default>
-        <expression>state_change/getHistory</expression>
-    </default>
-    <guard>
-        <guard-permission>Request review</guard-permission>
-        <guard-permission>Review portal content</guard-permission>
-    </guard>
-</variable>
-  <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
-    <description>When the previous transition was performed</description>
-    <default>
-        <expression>state_change/getDateTime</expression>
-    </default>
-    <guard/>
-</variable>
+<?xml version="1.0"?>
+<dc-workflow workflow_id="my_custom_workflow" title="My Custom Workflow" description="A three state publication workflow" state_variable="review_state" initial_state="my_custom_workflow--STATUS--private" manager_bypass="True">
+ <permission>ATContentTypes: Add Image</permission>
+ <permission>Access contents information</permission>
+ <permission>Add portal content</permission>
+ <permission>Delete objects</permission>
+ <permission>Modify portal content</permission>
+ <permission>View</permission>
+ <state state_id="my_custom_workflow--STATUS--pending" title="Pending">
+  <exit-transition transition_id="my_custom_workflow--TRANSITION--publish--pending_published"/>
+  <exit-transition transition_id="my_custom_workflow--TRANSITION--reject--pending_private"/>
+  <exit-transition transition_id="my_custom_workflow--TRANSITION--retract--pending_private"/>
+  <permission-map acquired="False" name="ATContentTypes: Add Image">
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+ </state>
+ <state state_id="my_custom_workflow--STATUS--private" title="Private">
+  <exit-transition transition_id="my_custom_workflow--TRANSITION--publish--private_published"/>
+  <exit-transition transition_id="my_custom_workflow--TRANSITION--submit-for-publication--private_pending"/>
+  <permission-map acquired="False" name="ATContentTypes: Add Image">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+ </state>
+ <state state_id="my_custom_workflow--STATUS--published" title="Published">
+  <exit-transition transition_id="my_custom_workflow--TRANSITION--retract--published_private"/>
+  <permission-map acquired="False" name="ATContentTypes: Add Image">
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Access contents information" acquired="False">
+   <permission-role>Anonymous</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Add portal content" acquired="False">
+   <permission-role>Editor</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+  <permission-map name="Delete objects" acquired="False">
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="Modify portal content" acquired="False">
+   <permission-role>Site Administrator</permission-role>
+  </permission-map>
+  <permission-map name="View" acquired="False">
+   <permission-role>Anonymous</permission-role>
+   <permission-role>Editor</permission-role>
+   <permission-role>Site Administrator</permission-role>
+   <permission-role>Reviewer</permission-role>
+  </permission-map>
+ </state>
+ <transition transition_id="my_custom_workflow--TRANSITION--publish--pending_published" title="publish" new_state="my_custom_workflow--STATUS--published" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--publish--pending_published" category="workflow" icon="">publish</action>
+  <guard>
+   <guard-expression>here/transition_guard_pending_published</guard-expression>
+   <guard-role>Reviewer</guard-role>
+   <guard-role>Site Administrator</guard-role>
+  </guard>
+ </transition>
+ <transition transition_id="my_custom_workflow--TRANSITION--publish--private_published" title="publish" new_state="my_custom_workflow--STATUS--published" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--publish--private_published" category="workflow" icon="">publish</action>
+  <guard>
+   <guard-role>Reviewer</guard-role>
+   <guard-role>Site Administrator</guard-role>
+  </guard>
+ </transition>
+ <transition transition_id="my_custom_workflow--TRANSITION--reject--pending_private" title="reject" new_state="my_custom_workflow--STATUS--private" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--reject--pending_private" category="workflow" icon="">reject</action>
+  <guard>
+   <guard-role>Reviewer</guard-role>
+  </guard>
+ </transition>
+ <transition transition_id="my_custom_workflow--TRANSITION--retract--pending_private" title="retract" new_state="my_custom_workflow--STATUS--private" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--retract--pending_private" category="workflow" icon="">retract</action>
+  <guard>
+   <guard-expression>python:here.guard(state_change)</guard-expression>
+   <guard-role>Editor</guard-role>
+  </guard>
+ </transition>
+ <transition transition_id="my_custom_workflow--TRANSITION--retract--published_private" title="retract" new_state="my_custom_workflow--STATUS--private" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--retract--published_private" category="workflow" icon="">retract</action>
+  <guard>
+   <guard-role>Reviewer</guard-role>
+   <guard-role>Editor</guard-role>
+  </guard>
+ </transition>
+ <transition transition_id="my_custom_workflow--TRANSITION--submit-for-publication--private_pending" title="submit for publication" new_state="my_custom_workflow--STATUS--pending" trigger="USER" before_script="" after_script="">
+  <action url="%(content_url)s/custom_wf_action?workflow_action=my_custom_workflow--TRANSITION--submit-for-publication--private_pending" category="workflow" icon="">submit for publication</action>
+  <guard>
+   <guard-role>Editor</guard-role>
+  </guard>
+ </transition>
+ <worklist worklist_id="my_custom_workflow--WORKLIST--pending" title="">
+  <action url="%(portal_url)s/search?review_state=my_custom_workflow--STATUS--pending" category="global" icon="">Pending (%(count)d)</action>
+  <guard>
+   <guard-role>Reviewer</guard-role>
+  </guard>
+  <match name="review_state" values="my_custom_workflow--STATUS--pending"/>
+ </worklist>
+ <variable variable_id="action" for_catalog="False" for_status="True" update_always="True">
+  <description>Previous transition</description>
+  <default>
+
+   <expression>transition/getId|nothing</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="actor" for_catalog="False" for_status="True" update_always="True">
+  <description>The ID of the user who performed the previous transition</description>
+  <default>
+
+   <expression>user/getId</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="comments" for_catalog="False" for_status="True" update_always="True">
+  <description>Comment about the last transition</description>
+  <default>
+
+   <expression>python:state_change.kwargs.get('comment', '')</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
+ <variable variable_id="review_history" for_catalog="False" for_status="False" update_always="False">
+  <description>Provides access to workflow history</description>
+  <default>
+
+   <expression>state_change/getHistory</expression>
+  </default>
+  <guard>
+   <guard-permission>Request review</guard-permission>
+   <guard-permission>Review portal content</guard-permission>
+  </guard>
+ </variable>
+ <variable variable_id="time" for_catalog="False" for_status="True" update_always="True">
+  <description>When the previous transition was performed</description>
+  <default>
+
+   <expression>state_change/getDateTime</expression>
+  </default>
+  <guard>
+  </guard>
+ </variable>
 </dc-workflow>

--- a/ftw/lawgiver/tests/locales/en/LC_MESSAGES/plone.po
+++ b/ftw/lawgiver/tests/locales/en/LC_MESSAGES/plone.po
@@ -11,6 +11,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#. Default: "Published"
+#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
+msgid "Published"
+msgstr "Published"
+
 msgid "local-roles--ROLE--Editor"
 msgstr "Editor"
 
@@ -52,11 +57,6 @@ msgstr "The editor-in-chief reviews and publishes content."
 msgid "publish"
 msgstr "publish"
 
-#. Default: "Published"
-#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "published"
-msgstr "Published"
-
 #. Default: "reject"
 #: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "reject"
@@ -80,15 +80,15 @@ msgstr "submit for publication"
 
 #. Default: "editor"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "wf-bar-role-editor"
+msgid "wf-bar--ROLE--Editor"
 msgstr "editor"
 
 #. Default: "System Administrator"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "wf-bar-role-manager"
+msgid "wf-bar--ROLE--Manager"
 msgstr "System Administrator"
 
 #. Default: "Published"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "wf-bar-status-published"
+msgid "wf-bar--STATUS--published"
 msgstr "Published"

--- a/ftw/lawgiver/tests/locales/plone.pot
+++ b/ftw/lawgiver/tests/locales/plone.pot
@@ -14,6 +14,11 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0\n"
 "Preferred-Encodings: utf-8 latin1\n"
 
+#. Default: "Published"
+#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
+msgid "Published"
+msgstr ""
+
 msgid "local-roles--ROLE--Editor"
 msgstr ""
 
@@ -55,11 +60,6 @@ msgstr ""
 msgid "publish"
 msgstr ""
 
-#. Default: "Published"
-#: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "published"
-msgstr ""
-
 #. Default: "reject"
 #: ftw/lawgiver/tests/profiles/custom-workflow/workflows/my_custom_workflow/specification.txt
 msgid "reject"
@@ -83,15 +83,15 @@ msgstr ""
 
 #. Default: "editor"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "wf-bar-role-editor"
+msgid "wf-bar--ROLE--Editor"
 msgstr ""
 
 #. Default: "System Administrator"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "wf-bar-role-manager"
+msgid "wf-bar--ROLE--Manager"
 msgstr ""
 
 #. Default: "Published"
 #: ftw/lawgiver/tests/profiles/bar/workflows/wf-bar/specification.txt
-msgid "wf-bar-status-published"
+msgid "wf-bar--STATUS--published"
 msgstr ""

--- a/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/definition.xml
+++ b/ftw/lawgiver/tests/profiles/role-translation/workflows/role-translation/definition.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<dc-workflow workflow_id="role-translation" title="role-translation-workflow" description="A one state workflow for testing role translation" initial_state="role-translation--STATUS--default" state_variable="review_state" manager_bypass="True">
+<dc-workflow workflow_id="role-translation" title="Role Translation Workflow" description="A one state workflow for testing role translation" initial_state="role-translation--STATUS--default" state_variable="review_state" manager_bypass="True">
   <permission>ATContentTypes: Add Document</permission>
   <permission>ATContentTypes: Add Event</permission>
   <permission>ATContentTypes: Add File</permission>
@@ -21,6 +21,7 @@
   <permission>CMFEditions: Save new version</permission>
   <permission>Change local roles</permission>
   <permission>Delete objects</permission>
+  <permission>Delete portal content</permission>
   <permission>Edit comments</permission>
   <permission>List folder contents</permission>
   <permission>Manage properties</permission>
@@ -47,9 +48,10 @@
   <permission>plone.app.contenttypes: Add Link</permission>
   <permission>plone.app.contenttypes: Add News Item</permission>
   <permission>plone.app.event: Import Ical</permission>
+  <permission>plone.app.multilingual: Manage Translations</permission>
   <permission>plone.portlet.collection: Add collection portlet</permission>
   <permission>plone.portlet.static: Add static portlet</permission>
-  <state state_id="role-translation--STATUS--default" title="default">
+  <state state_id="role-translation--STATUS--default" title="Default">
     <permission-map name="ATContentTypes: Add Document" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>
@@ -149,6 +151,11 @@
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="Delete objects" acquired="False">
+      <permission-role>Editor</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Site Administrator</permission-role>
+    </permission-map>
+    <permission-map name="Delete portal content" acquired="False">
       <permission-role>Editor</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Site Administrator</permission-role>
@@ -255,6 +262,7 @@
       <permission-role>Site Administrator</permission-role>
     </permission-map>
     <permission-map name="plone.app.event: Import Ical" acquired="False"/>
+    <permission-map name="plone.app.multilingual: Manage Translations" acquired="False"/>
     <permission-map name="plone.portlet.collection: Add collection portlet" acquired="False"/>
     <permission-map name="plone.portlet.static: Add static portlet" acquired="False"/>
   </state>

--- a/ftw/lawgiver/tests/test_generator_unit.py
+++ b/ftw/lawgiver/tests/test_generator_unit.py
@@ -53,12 +53,12 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'example-workflow',
-            'title': 'example-workflow',
+            'title': 'Example Workflow',
             'description': 'the Description',
             'initial_status': 'example-workflow--STATUS--foo'} % (
 
             workflowxml.STATUS_STANDALONE % {
-                'title': 'foo',
+                'title': 'Foo',
                 'id': 'example-workflow--STATUS--foo',
                 })
 
@@ -76,12 +76,12 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'workflow',
-            'title': 'workflow',
+            'title': 'W\xc3\xb6rkflow',
             'description': '',
             'initial_status': 'workflow--STATUS--hello-world'} % (
 
             workflowxml.STATUS_STANDALONE % {
-                'title': 'hello-world',
+                'title': status_title,
                 'id': 'workflow--STATUS--hello-world',
                 })
 
@@ -102,31 +102,31 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'workflow',
-            'title': 'wf',
+            'title': 'WF',
             'description': '',
             'initial_status': 'workflow--STATUS--foo'} % ''.join((
 
                 workflowxml.STATUS % {
-                    'title': 'bar',
+                    'title': 'Bar',
                     'id': 'workflow--STATUS--bar',
                     } % (workflowxml.EXIT_TRANSITION %
                          'workflow--TRANSITION--fuize--bar_foo'),
 
                 workflowxml.STATUS % {
-                    'title': 'foo',
+                    'title': 'Foo',
                     'id': 'workflow--STATUS--foo',
                     } % (workflowxml.EXIT_TRANSITION %
                          'workflow--TRANSITION--barize--foo_bar'),
 
                 workflowxml.TRANSITION % {
                     'id': 'workflow--TRANSITION--barize--foo_bar',
-                    'title': 'barize',
+                    'title': 'b\xc3\xa4rize',
                     'target_state': 'workflow--STATUS--bar',
                     'guards': workflowxml.GUARDS_DISABLED},
 
                 workflowxml.TRANSITION % {
                     'id': 'workflow--TRANSITION--fuize--bar_foo',
-                    'title': 'fuize',
+                    'title': 'f\xc3\xbcize',
                     'target_state': 'workflow--STATUS--foo',
                     'guards': workflowxml.GUARDS_DISABLED},
 
@@ -152,32 +152,32 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'workflow',
-            'title': 'wf',
+            'title': 'WF',
             'description': '',
             'initial_status': 'workflow--STATUS--foo'} % ''.join((
 
                 workflowxml.STATUS % {
-                    'title': 'bar',
+                    'title': 'Bar',
                     'id': 'workflow--STATUS--bar',
                     } % (workflowxml.EXIT_TRANSITION %
                          'workflow--TRANSITION--fuize--bar_foo'),
 
                 workflowxml.STATUS % {
-                    'title': 'foo',
+                    'title': 'Foo',
                     'id': 'workflow--STATUS--foo',
                     } % (workflowxml.EXIT_TRANSITION %
                          'workflow--TRANSITION--barize--foo_bar'),
 
                 workflowxml.TRANSITION_WITH_CUSTOM_URL % {
                     'id': 'workflow--TRANSITION--barize--foo_bar',
-                    'title': 'barize',
+                    'title': 'b\xc3\xa4rize',
                     'target_state': 'workflow--STATUS--bar',
                     'guards': workflowxml.GUARDS_DISABLED,
                     'url_viewname': 'custom_wf_action'},
 
                 workflowxml.TRANSITION_WITH_CUSTOM_URL % {
                     'id': 'workflow--TRANSITION--fuize--bar_foo',
-                    'title': 'fuize',
+                    'title': 'f\xc3\xbcize',
                     'target_state': 'workflow--STATUS--foo',
                     'guards': workflowxml.GUARDS_DISABLED,
                     'url_viewname': 'custom_wf_action'},
@@ -222,7 +222,7 @@ class TestGenerator(BaseTest):
                 ))
 
         xml_status_defininition = workflowxml.STATUS % {
-            'title': 'foo',
+            'title': 'Foo',
             'id': 'example-workflow--STATUS--foo',
             } % ''.join((
 
@@ -244,7 +244,7 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'example-workflow',
-            'title': 'workflow',
+            'title': 'Workflow',
             'description': '',
             'initial_status': 'example-workflow--STATUS--foo'} % ''.join((
                 xml_permissions_declaration,
@@ -275,18 +275,18 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'wf',
-            'title': 'workflow',
+            'title': 'Workflow',
             'description': '',
             'initial_status': 'wf--STATUS--private'} % ''.join((
 
                 workflowxml.STATUS % {
-                    'title': 'private',
+                    'title': 'Private',
                     'id': 'wf--STATUS--private',
                     } % workflowxml.EXIT_TRANSITION % (
                     'wf--TRANSITION--publish--private_published'),
 
                 workflowxml.STATUS % {
-                    'title': 'published',
+                    'title': 'Published',
                     'id': 'wf--STATUS--published',
                     } % workflowxml.EXIT_TRANSITION % (
                     'wf--TRANSITION--retract--published_private'),
@@ -453,7 +453,7 @@ class TestGenerator(BaseTest):
                 ))
 
         xml_foo_defininition = workflowxml.STATUS % {
-            'title': 'foo',
+            'title': 'Foo',
             'id': 'example-workflow--STATUS--foo',
             } % ''.join((
 
@@ -482,7 +482,7 @@ class TestGenerator(BaseTest):
                 ))
 
         xml_bar_defininition = workflowxml.STATUS % {
-            'title': 'bar',
+            'title': 'Bar',
             'id': 'example-workflow--STATUS--bar',
             } % ''.join((
 
@@ -517,7 +517,7 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'example-workflow',
-            'title': 'workflow',
+            'title': 'Workflow',
             'description': '',
             'initial_status': 'example-workflow--STATUS--foo'} % ''.join((
                 xml_permissions_declaration,
@@ -545,19 +545,19 @@ class TestGenerator(BaseTest):
 
         expected = workflowxml.WORKFLOW % {
             'id': 'wf',
-            'title': 'workflow',
+            'title': 'Workflow',
             'description': '',
             'initial_status': 'wf--STATUS--pending'} % ''.join((
 
                 workflowxml.STATUS_STANDALONE % {
-                    'title': 'pending',
+                    'title': 'Pending',
                     'id': 'wf--STATUS--pending',
                     },
 
                 workflowxml.WORKLIST % {
                     'id': 'wf--WORKLIST--pending',
                     'status_id': 'wf--STATUS--pending',
-                    'status_title': 'pending',
+                    'status_title': 'Pending',
                     'guards': workflowxml.GUARDS % ''.join((
                             workflowxml.GUARD_ROLE % 'Editor',
                             workflowxml.GUARD_ROLE % 'Reviewer',

--- a/ftw/lawgiver/tests/test_i18nbuilder.py
+++ b/ftw/lawgiver/tests/test_i18nbuilder.py
@@ -16,53 +16,53 @@ POT_PATH = os.path.join(I18N_ASSETS, 'locales', 'plone.pot')
 EN_PO_PATH = os.path.join(
     I18N_ASSETS, 'locales', 'en', 'LC_MESSAGES', 'plone.po')
 
-SIMPLE_WORKFLOW_MESSAGES = r'''
-#. Default: "püblish"
-#: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "pa1-4blish"
-msgstr "püblish"
 
+SIMPLE_WORKFLOW_MESSAGES = r'''
 #. Default: "Private"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "private"
+msgid "Private"
 msgstr "Private"
 
 #. Default: "Published"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "published"
+msgid "Published"
 msgstr "Published"
 
-#. Default: "An \"Editor\" writes articles."
+#. Default: "püblish"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "simple_workflow-role-description-editor"
-msgstr "An \"Editor\" writes articles."
+msgid "püblish"
+msgstr "püblish"
 
 #. Default: "editor"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "simple_workflow-role-editor"
+msgid "simple_workflow--ROLE--Editor"
 msgstr "editor"
+
+#. Default: "An \"Editor\" writes articles."
+#: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
+msgid "simple_workflow--ROLE-DESCRIPTION--Editor"
+msgstr "An \"Editor\" writes articles."
 
 #. Default: "Private"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "simple_workflow-status-private"
+msgid "simple_workflow--STATUS--private"
 msgstr "Private"
 
 #. Default: "Published"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "simple_workflow-status-published"
+msgid "simple_workflow--STATUS--published"
 msgstr "Published"
 
 #. Default: "püblish"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "simple_workflow-transition-publish"
+msgid "simple_workflow--TRANSITION--publish--private_published"
 msgstr "püblish"
 '''.strip()
-
 
 OLD_SIMPLE_WORKFLOW_MESSAGES = r'''
 #. Default: "No Longer Available"
 #: ftw/lawgiver/tests/assets/i18nbuilder/profiles/default/workflows/simple_workflow/specification.txt
-msgid "no-longer-available"
+msgid "No Longer Available"
 msgstr "No Longer Available"
 '''
 

--- a/ftw/lawgiver/tests/test_view_details.py
+++ b/ftw/lawgiver/tests/test_view_details.py
@@ -6,7 +6,6 @@ from ftw.testbrowser import browsing
 from ftw.testbrowser.pages import plone
 from ftw.testbrowser.pages import statusmessages
 from operator import methodcaller
-from plone.i18n.normalizer import idnormalizer
 from unittest import TestCase
 import os
 import shutil
@@ -191,7 +190,7 @@ class TestBARSpecificationDetailsViewINSTALLED(TestCase):
             wftool = getToolByName(self.layer['portal'], 'portal_workflow')
             return wftool.get('wf-bar')
 
-        self.assertEquals('bar-workflow', get_workflow().title,
+        self.assertEquals('Bar Workflow', get_workflow().title,
                           'Workflow title wrong after initial import.')
 
         # Change the workflow title in the database
@@ -201,7 +200,7 @@ class TestBARSpecificationDetailsViewINSTALLED(TestCase):
         # reimport with our button
         specdetails.button_write_and_import().click()
         self.assertEquals(
-            'bar-workflow', get_workflow().title,
+            'Bar Workflow', get_workflow().title,
             'Workflow title - write / reimport seems not working?')
 
         statusmessages.assert_message('Workflow wf-bar successfully imported.')


### PR DESCRIPTION
Reverts 4teamwork/ftw.lawgiver#97

Until the fix in https://github.com/plone/plone.app.content/pull/192 gets merged we can use the fork https://github.com/4teamwork/plone.app.content/tree/plone_5.1_fixed_non_ascii to fix the UnicodeError. 

This can be done with the following added to the appropriate `cfg` file:
```
auto-checkout =
    plone.app.content

[forks]
plone.app.content = 4teamwork

[branches]
plone.app.content = plone_5.1_fixed_non_ascii
```