### PR TITLE
Ignore permissions introduced by Products.PloneHotfix20200121.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.17.4 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Ignore permissions introduced by Products.PloneHotfix20200121. [jone]
 
 
 1.17.3 (2019-12-10)

--- a/ftw/lawgiver/lawgiver.zcml
+++ b/ftw/lawgiver/lawgiver.zcml
@@ -360,4 +360,13 @@
                      "
         />
 
+    <!-- Products.PloneHotfix20200121 introduces new permissions. -->
+    <lawgiver:ignore
+        permissions="
+                     Change Database Connections,
+                     Open/Close Database Connection,
+                     Test Database Connections,
+                     "
+        />
+
 </configure>


### PR DESCRIPTION
The hotfix introduces new permissions which can be ignored.