### PR TITLE
Add constraint to draw attention to non-ASCII fix.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.17.5 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add version constraint in order to draw attention to the non-ASCII fix
+  in https://github.com/plone/plone.app.content/pull/192. [busykoala]
 
 
 1.17.4 (2020-01-22)

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,8 @@ setup(name='ftw.lawgiver',
         'lxml',
         'ordereddict',
         'path.py',
+        # Check out -> https://github.com/plone/plone.app.content/pull/192
+        'plone.app.content>=3.5.8',
         'plone.app.workflow',
         'plone.i18n',
         'setuptools',

--- a/test-plone-4.3.x-deletepermission.cfg
+++ b/test-plone-4.3.x-deletepermission.cfg
@@ -11,3 +11,6 @@ test-extras = tests, deletepermission
 # (plone.schema -> jsonschema -> importlib-metadata -> zipp)
 # and zipp version 0.6 is not python 3 compatible, though it claims to be
 zipp = 0.5.2
+
+# Check out -> https://github.com/plone/plone.app.content/pull/192
+plone.app.content = 3.5.8

--- a/test-plone-4.3.x-no-deletepermission.cfg
+++ b/test-plone-4.3.x-no-deletepermission.cfg
@@ -10,3 +10,6 @@ package-name = ftw.lawgiver
 # (plone.schema -> jsonschema -> importlib-metadata -> zipp)
 # and zipp version 0.6 is not python 3 compatible, though it claims to be
 zipp = 0.5.2
+
+# Check out -> https://github.com/plone/plone.app.content/pull/192
+plone.app.content = 3.5.8

--- a/test-plone-5.1.x-deletepermission.cfg
+++ b/test-plone-5.1.x-deletepermission.cfg
@@ -5,3 +5,7 @@ extends =
 
 package-name = ftw.lawgiver
 test-extras = tests, deletepermission
+
+[versions]
+# Check out -> https://github.com/plone/plone.app.content/pull/192
+plone.app.content = 3.5.8

--- a/test-plone-5.1.x-no-deletepermission.cfg
+++ b/test-plone-5.1.x-no-deletepermission.cfg
@@ -4,3 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.lawgiver
+
+[versions]
+# Check out -> https://github.com/plone/plone.app.content/pull/192
+plone.app.content = 3.5.8


### PR DESCRIPTION
I would love to add this to `ftw.lawgiver` so no one will run into this problem without a hint on how to fix it. Still, we have to pin it in every productive package accordingly but with this change, the one running into the problem will have a reference to the solution.