### PR TITLE
Pin down PyJWT to 1.7.1 and pyrsistent to 0.16.0 in order to fix tests.

### DIFF
--- a/test-plone-4.3.x-deletepermission.cfg
+++ b/test-plone-4.3.x-deletepermission.cfg
@@ -13,3 +13,5 @@ test-extras = tests, deletepermission
 zipp = 0.5.2
 # PyJWT 2.0.0 has dropped python 2 support.
 PyJWT = 1.7.1
+# pyrsistent 0.16.0 no longer guarantees python 2 support.
+pyrsistent = 0.15.7

--- a/test-plone-4.3.x-deletepermission.cfg
+++ b/test-plone-4.3.x-deletepermission.cfg
@@ -11,3 +11,5 @@ test-extras = tests, deletepermission
 # (plone.schema -> jsonschema -> importlib-metadata -> zipp)
 # and zipp version 0.6 is not python 3 compatible, though it claims to be
 zipp = 0.5.2
+# PyJWT 2.0.0 has dropped python 2 support.
+PyJWT = 1.7.1

--- a/test-plone-4.3.x-no-deletepermission.cfg
+++ b/test-plone-4.3.x-no-deletepermission.cfg
@@ -10,3 +10,5 @@ package-name = ftw.lawgiver
 # (plone.schema -> jsonschema -> importlib-metadata -> zipp)
 # and zipp version 0.6 is not python 3 compatible, though it claims to be
 zipp = 0.5.2
+# PyJWT 2.0.0 has dropped python 2 support.
+PyJWT = 1.7.1

--- a/test-plone-4.3.x-no-deletepermission.cfg
+++ b/test-plone-4.3.x-no-deletepermission.cfg
@@ -12,3 +12,5 @@ package-name = ftw.lawgiver
 zipp = 0.5.2
 # PyJWT 2.0.0 has dropped python 2 support.
 PyJWT = 1.7.1
+# pyrsistent 0.16.0 no longer guarantees python 2 support.
+pyrsistent = 0.15.7

--- a/test-plone-5.1.x-deletepermission.cfg
+++ b/test-plone-5.1.x-deletepermission.cfg
@@ -5,3 +5,7 @@ extends =
 
 package-name = ftw.lawgiver
 test-extras = tests, deletepermission
+
+[versions]
+# PyJWT 2.0.0 has dropped python 2 support.
+PyJWT = 1.7.1

--- a/test-plone-5.1.x-no-deletepermission.cfg
+++ b/test-plone-5.1.x-no-deletepermission.cfg
@@ -4,3 +4,7 @@ extends =
     sources.cfg
 
 package-name = ftw.lawgiver
+
+[versions]
+# PyJWT 2.0.0 has dropped python 2 support.
+PyJWT = 1.7.1


### PR DESCRIPTION
PyJWT >= 2.0.0 has dropped python 2 support, we pin to the latest available compatible version for testing.

See https://pyjwt.readthedocs.io/en/stable/changelog.html#v2-0-0.

pyrsistent >= 0.16.0 has dropped python 2 support, we pin to the latest available compatible version for testing.

See https://github.com/tobgu/pyrsistent/blob/master/CHANGES.txt.