### PR TITLE
Downpin plone.restapi to fix tests.

### DIFF
--- a/test-plone-4.3.x-deletepermission.cfg
+++ b/test-plone-4.3.x-deletepermission.cfg
@@ -15,3 +15,5 @@ zipp = 0.5.2
 PyJWT = 1.7.1
 # pyrsistent 0.16.0 no longer guarantees python 2 support.
 pyrsistent = 0.15.7
+# plone.restapi 8.0.0 drops python 2 and plone 4.3 and 5.1 support
+plone.restapi = <8.0.0

--- a/test-plone-4.3.x-no-deletepermission.cfg
+++ b/test-plone-4.3.x-no-deletepermission.cfg
@@ -14,3 +14,5 @@ zipp = 0.5.2
 PyJWT = 1.7.1
 # pyrsistent 0.16.0 no longer guarantees python 2 support.
 pyrsistent = 0.15.7
+# plone.restapi 8.0.0 drops python 2 and plone 4.3 and 5.1 support
+plone.restapi = <8.0.0

--- a/test-plone-5.1.x-deletepermission.cfg
+++ b/test-plone-5.1.x-deletepermission.cfg
@@ -9,3 +9,5 @@ test-extras = tests, deletepermission
 [versions]
 # PyJWT 2.0.0 has dropped python 2 support.
 PyJWT = 1.7.1
+# plone.restapi 8.0.0 drops python 2 and plone 4.3 and 5.1 support
+plone.restapi = <8.0.0

--- a/test-plone-5.1.x-no-deletepermission.cfg
+++ b/test-plone-5.1.x-no-deletepermission.cfg
@@ -8,3 +8,5 @@ package-name = ftw.lawgiver
 [versions]
 # PyJWT 2.0.0 has dropped python 2 support.
 PyJWT = 1.7.1
+# plone.restapi 8.0.0 drops python 2 and plone 4.3 and 5.1 support
+plone.restapi = <8.0.0


### PR DESCRIPTION
The new `plone.restapi` release `8.0.0` drops python 2 and plone 4.3 and 5.1 support.