### PR TITLE
Use jsonschema <4.0.0 to fix tests.

### DIFF
--- a/test-plone-4.3.x-deletepermission.cfg
+++ b/test-plone-4.3.x-deletepermission.cfg
@@ -17,3 +17,5 @@ PyJWT = 1.7.1
 pyrsistent = 0.15.7
 # plone.restapi 8.0.0 drops python 2 and plone 4.3 and 5.1 support
 plone.restapi = <8.0.0
+# jsonschema 4.0.0 has dropped python 2 support.
+jsonschema = <4.0.0

--- a/test-plone-4.3.x-no-deletepermission.cfg
+++ b/test-plone-4.3.x-no-deletepermission.cfg
@@ -16,3 +16,5 @@ PyJWT = 1.7.1
 pyrsistent = 0.15.7
 # plone.restapi 8.0.0 drops python 2 and plone 4.3 and 5.1 support
 plone.restapi = <8.0.0
+# jsonschema 4.0.0 has dropped python 2 support.
+jsonschema = <4.0.0


### PR DESCRIPTION
The package `jsonschema` has dropped python 2 support in version `4.0.0`.